### PR TITLE
style: black + isort the 5 training scripts (fix main Lint Code)

### DIFF
--- a/debug_training.py
+++ b/debug_training.py
@@ -4,12 +4,13 @@ Debug helper script for ELVIS training system
 Diagnoses common issues and provides troubleshooting information
 """
 
-import os
-import sys
-import logging
-import subprocess
-from pathlib import Path
 import importlib.util
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 
 def check_python_environment():
     """Check Python environment and virtual environment"""
@@ -17,28 +18,39 @@ def check_python_environment():
     print("-" * 40)
     print(f"Python version: {sys.version}")
     print(f"Python executable: {sys.executable}")
-    
+
     # Check if in virtual environment
-    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+    if hasattr(sys, "real_prefix") or (
+        hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+    ):
         print("✅ Running in virtual environment")
     else:
         print("⚠️  Not running in virtual environment")
-    
+
     print()
+
 
 def check_required_packages():
     """Check if required Python packages are installed"""
     print("📦 Package Dependencies Check")
     print("-" * 40)
-    
+
     required_packages = [
-        'pandas', 'numpy', 'torch', 'tensorflow', 'sklearn', 
-        'hvac', 'redis', 'psycopg2', 'binance', 'ta'
+        "pandas",
+        "numpy",
+        "torch",
+        "tensorflow",
+        "sklearn",
+        "hvac",
+        "redis",
+        "psycopg2",
+        "binance",
+        "ta",
     ]
-    
+
     missing_packages = []
     available_packages = []
-    
+
     for package in required_packages:
         spec = importlib.util.find_spec(package)
         if spec is None:
@@ -47,37 +59,44 @@ def check_required_packages():
         else:
             print(f"✅ {package}: Available")
             available_packages.append(package)
-    
+
     if missing_packages:
         print(f"\n⚠️  Missing packages: {', '.join(missing_packages)}")
-        print("💡 Install with: pip install " + ' '.join(missing_packages))
+        print("💡 Install with: pip install " + " ".join(missing_packages))
     else:
         print("\n✅ All required packages are available")
-    
+
     print()
     return len(missing_packages) == 0
+
 
 def check_vault_connection():
     """Check Vault server connection and authentication"""
     print("🔐 Vault Connection Check")
     print("-" * 40)
-    
-    vault_addr = os.getenv('VAULT_ADDR', 'http://127.0.0.1:8200')
-    vault_token = os.getenv('VAULT_TOKEN')
-    
+
+    vault_addr = os.getenv("VAULT_ADDR", "http://127.0.0.1:8200")
+    vault_token = os.getenv("VAULT_TOKEN")
+
     print(f"VAULT_ADDR: {vault_addr}")
     print(f"VAULT_TOKEN: {'Set' if vault_token else 'Not set'}")
-    
+
     try:
-        result = subprocess.run(['vault', 'status'], 
-                              capture_output=True, text=True, timeout=5)
+        result = subprocess.run(
+            ["vault", "status"], capture_output=True, text=True, timeout=5
+        )
         if result.returncode == 0:
             print("✅ Vault server is running")
-            
+
             # Check authentication
             try:
-                auth_result = subprocess.run(['vault', 'auth', '-method=token'], 
-                                           input=vault_token, capture_output=True, text=True, timeout=5)
+                auth_result = subprocess.run(
+                    ["vault", "auth", "-method=token"],
+                    input=vault_token,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
                 if auth_result.returncode == 0:
                     print("✅ Vault authentication successful")
                 else:
@@ -85,10 +104,12 @@ def check_vault_connection():
                     print(f"Error: {auth_result.stderr}")
             except Exception as e:
                 print(f"❌ Vault auth check failed: {e}")
-                
+
         else:
             print("❌ Vault server is not running")
-            print("💡 Start with: vault server -dev -dev-root-token-id=<choose-a-local-dev-token>")
+            print(
+                "💡 Start with: vault server -dev -dev-root-token-id=<choose-a-local-dev-token>"
+            )
     except FileNotFoundError:
         print("❌ Vault CLI not found")
         print("💡 Install Vault: https://www.vaultproject.io/downloads")
@@ -96,14 +117,15 @@ def check_vault_connection():
         print("⏰ Vault connection timeout")
     except Exception as e:
         print(f"❌ Vault check failed: {e}")
-    
+
     print()
+
 
 def check_database_connection():
     """Check database connectivity"""
-    print("🗄️  Database Connection Check") 
+    print("🗄️  Database Connection Check")
     print("-" * 40)
-    
+
     # Check if paper_trades.db exists
     db_path = Path("paper_trades.db")
     if db_path.exists():
@@ -112,52 +134,53 @@ def check_database_connection():
     else:
         print("❌ SQLite database not found: paper_trades.db")
         print("💡 Database will be created on first run")
-    
+
     print()
+
 
 def check_training_files():
     """Check training-related files and directories"""
     print("📁 Training Files Check")
     print("-" * 40)
-    
+
     required_files = [
-        'training/train_models.py',
-        'training/config/model_config.yaml',
-        'main.py',
-        'config/config.py'
+        "training/train_models.py",
+        "training/config/model_config.yaml",
+        "main.py",
+        "config/config.py",
     ]
-    
-    required_dirs = [
-        'models',
-        'training/data',
-        'utils',
-        'core/models'
-    ]
-    
+
+    required_dirs = ["models", "training/data", "utils", "core/models"]
+
     # Check files
     for file_path in required_files:
         if Path(file_path).exists():
             print(f"✅ {file_path}")
         else:
             print(f"❌ {file_path}: Missing")
-    
+
     # Check directories
     for dir_path in required_dirs:
         if Path(dir_path).exists():
             print(f"✅ {dir_path}/")
         else:
             print(f"❌ {dir_path}/: Missing")
-            
+
     print()
+
 
 def check_model_files():
     """Check existing model files"""
     print("🤖 Model Files Check")
     print("-" * 40)
-    
+
     models_dir = Path("models")
     if models_dir.exists():
-        model_files = list(models_dir.glob("*.pth")) + list(models_dir.glob("*.pkl")) + list(models_dir.glob("*.json"))
+        model_files = (
+            list(models_dir.glob("*.pth"))
+            + list(models_dir.glob("*.pkl"))
+            + list(models_dir.glob("*.json"))
+        )
         if model_files:
             print(f"Found {len(model_files)} model files:")
             for model_file in sorted(model_files)[:10]:  # Show first 10
@@ -168,75 +191,84 @@ def check_model_files():
             print("No trained models found")
     else:
         print("Models directory does not exist")
-    
+
     print()
+
 
 def run_quick_test():
     """Run a quick test of core functionality"""
     print("🧪 Quick Functionality Test")
     print("-" * 40)
-    
+
     try:
         # Test imports
-        import pandas as pd
         import numpy as np
+        import pandas as pd
+
         print("✅ Core data libraries import OK")
-        
+
         # Test basic data processing
-        test_data = pd.DataFrame({
-            'price': np.random.randn(100),
-            'volume': np.random.randn(100)
-        })
-        test_data['sma'] = test_data['price'].rolling(10).mean()
+        test_data = pd.DataFrame(
+            {"price": np.random.randn(100), "volume": np.random.randn(100)}
+        )
+        test_data["sma"] = test_data["price"].rolling(10).mean()
         print("✅ Basic data processing OK")
-        
+
         # Test configuration loading
-        sys.path.append('.')
+        sys.path.append(".")
         from config.config import TRADING_CONFIG
+
         print("✅ Configuration loading OK")
-        
+
         print("✅ All quick tests passed")
-        
+
     except Exception as e:
         print(f"❌ Quick test failed: {e}")
         import traceback
+
         traceback.print_exc()
-    
+
     print()
+
 
 def provide_recommendations():
     """Provide troubleshooting recommendations"""
     print("💡 Troubleshooting Recommendations")
     print("-" * 40)
-    
+
     print("1. 🔐 For Vault issues:")
-    print("   - Start Vault: vault server -dev -dev-root-token-id=<choose-a-local-dev-token>")
+    print(
+        "   - Start Vault: vault server -dev -dev-root-token-id=<choose-a-local-dev-token>"
+    )
     print("   - Set environment: export VAULT_ADDR=http://127.0.0.1:8200")
     print("   - Set token: export VAULT_TOKEN=<choose-a-local-dev-token>")
     print()
-    
+
     print("2. 📦 For missing dependencies:")
     print("   - Install requirements: pip install -r requirements.txt")
-    print("   - Use virtual environment: python -m venv venv && source venv/bin/activate")
+    print(
+        "   - Use virtual environment: python -m venv venv && source venv/bin/activate"
+    )
     print()
-    
+
     print("3. 🗄️  For database issues:")
     print("   - Check PostgreSQL is running: pg_ctl status")
     print("   - Reset paper trading: python reset_paper_trading.py")
     print()
-    
+
     print("4. 🚀 For training issues:")
     print("   - Start small: ./train_with_trades.py --limit 100 --epochs 5 --debug")
     print("   - Skip Vault: ./train_with_trades.py --no-vault --debug")
     print("   - Check logs in models/ directory")
     print()
 
+
 def main():
     """Main diagnostic function"""
     print("🔧 ELVIS Training System Diagnostic Tool")
     print("=" * 50)
     print()
-    
+
     # Run all checks
     check_python_environment()
     packages_ok = check_required_packages()
@@ -244,14 +276,15 @@ def main():
     check_database_connection()
     check_training_files()
     check_model_files()
-    
+
     if packages_ok:
         run_quick_test()
-    
+
     provide_recommendations()
-    
+
     print("🏁 Diagnostic complete!")
     print("💡 Run './train_with_trades.py --debug --limit 100' to test training")
+
 
 if __name__ == "__main__":
     main()

--- a/train_no_vault.py
+++ b/train_no_vault.py
@@ -4,39 +4,41 @@ Training script that completely bypasses Vault authentication
 Uses environment variables only for training purposes
 """
 
-import os
-import sys
-import subprocess
 import argparse
 import logging
+import os
+import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
+
 
 def setup_training_environment():
     """Setup environment variables for training without Vault"""
     print("🔧 Setting up training environment (Vault-free)...")
-    
+
     # Disable Vault completely
-    os.environ['VAULT_ENABLED'] = 'false'
-    os.environ['USE_VAULT'] = 'false'
-    os.environ['VAULT_AVAILABLE'] = 'false'
-    
+    os.environ["VAULT_ENABLED"] = "false"
+    os.environ["USE_VAULT"] = "false"
+    os.environ["VAULT_AVAILABLE"] = "false"
+
     # Set training credentials (these are safe for paper trading)
-    os.environ['BINANCE_API_KEY'] = 'training_mode_key'
-    os.environ['BINANCE_API_SECRET'] = 'training_mode_secret'
-    
+    os.environ["BINANCE_API_KEY"] = "training_mode_key"
+    os.environ["BINANCE_API_SECRET"] = "training_mode_secret"
+
     # Database settings for training
-    os.environ['POSTGRES_HOST'] = 'localhost'
-    os.environ['POSTGRES_PORT'] = '5432'
-    os.environ['POSTGRES_USER'] = 'postgres'
-    os.environ['POSTGRES_PASSWORD'] = 'training_password'
-    os.environ['POSTGRES_DBNAME'] = 'trading_db'
-    
+    os.environ["POSTGRES_HOST"] = "localhost"
+    os.environ["POSTGRES_PORT"] = "5432"
+    os.environ["POSTGRES_USER"] = "postgres"
+    os.environ["POSTGRES_PASSWORD"] = "training_password"
+    os.environ["POSTGRES_DBNAME"] = "trading_db"
+
     # Redis settings
-    os.environ['REDIS_HOST'] = 'localhost'
-    os.environ['REDIS_PORT'] = '6379'
-    
+    os.environ["REDIS_HOST"] = "localhost"
+    os.environ["REDIS_PORT"] = "6379"
+
     print("✅ Training environment configured")
+
 
 def patch_imports():
     """Patch Python path to avoid Vault imports"""
@@ -44,7 +46,7 @@ def patch_imports():
     current_dir = Path(__file__).parent.absolute()
     if str(current_dir) not in sys.path:
         sys.path.insert(0, str(current_dir))
-    
+
     # Create a mock vault client if needed
     mock_vault = """
 class VaultClient:
@@ -55,37 +57,40 @@ class VaultClient:
     def get_secret(self, *args, **kwargs):
         return None
 """
-    
-    with open('vault_mock.py', 'w') as f:
+
+    with open("vault_mock.py", "w") as f:
         f.write(mock_vault)
+
 
 def run_training(args):
     """Run training with vault-free environment"""
     print("🚀 Starting Vault-free training...")
     print("=" * 50)
-    
+
     # Setup environment
     setup_training_environment()
     patch_imports()
-    
+
     # Build training command
     cmd_parts = [
         sys.executable,
-        'training/train_models.py',
-        '--include-trade-history',
-        '--config', args.config,
-        '--output', args.output,
+        "training/train_models.py",
+        "--include-trade-history",
+        "--config",
+        args.config,
+        "--output",
+        args.output,
     ]
-    
+
     if args.debug:
-        cmd_parts.append('--debug')
-        os.environ['LOG_LEVEL'] = 'DEBUG'
-    
+        cmd_parts.append("--debug")
+        os.environ["LOG_LEVEL"] = "DEBUG"
+
     # Set training parameters
-    os.environ['TRADE_LIMIT'] = str(args.limit)
-    os.environ['PREDICTION_HORIZON'] = str(args.prediction_horizon)
-    os.environ['TRAINING_EPOCHS'] = str(args.epochs)
-    
+    os.environ["TRADE_LIMIT"] = str(args.limit)
+    os.environ["PREDICTION_HORIZON"] = str(args.prediction_horizon)
+    os.environ["TRAINING_EPOCHS"] = str(args.epochs)
+
     print(f"📊 Training Parameters:")
     print(f"   Limit: {args.limit} trades")
     print(f"   Epochs: {args.epochs}")
@@ -93,56 +98,60 @@ def run_training(args):
     print(f"   Debug: {args.debug}")
     print(f"⏰ Started: {datetime.now().strftime('%H:%M:%S')}")
     print()
-    
+
     try:
         # Run training with clean environment
         result = subprocess.run(
-            cmd_parts,
-            env=os.environ.copy(),
-            cwd=str(Path(__file__).parent)
+            cmd_parts, env=os.environ.copy(), cwd=str(Path(__file__).parent)
         )
-        
+
         if result.returncode == 0:
             print(f"\n✅ Training completed successfully!")
             print(f"🕒 Finished: {datetime.now().strftime('%H:%M:%S')}")
             print(f"📂 Check {args.output}/ for results")
         else:
             print(f"\n❌ Training failed with code {result.returncode}")
-            
+
     except KeyboardInterrupt:
         print("\n⚠️  Training interrupted")
     except Exception as e:
         print(f"\n❌ Training error: {e}")
 
+
 def main():
     """Main function"""
-    parser = argparse.ArgumentParser(description='Train ELVIS models without Vault')
-    parser.add_argument('--limit', type=int, default=500, help='Max trades to use')
-    parser.add_argument('--epochs', type=int, default=5, help='Training epochs')  
-    parser.add_argument('--prediction-horizon', type=int, default=5, help='Prediction horizon')
-    parser.add_argument('--config', default='training/config/model_config.yaml', help='Config file')
-    parser.add_argument('--output', default='models', help='Output directory')
-    parser.add_argument('--debug', action='store_true', help='Debug mode')
-    
+    parser = argparse.ArgumentParser(description="Train ELVIS models without Vault")
+    parser.add_argument("--limit", type=int, default=500, help="Max trades to use")
+    parser.add_argument("--epochs", type=int, default=5, help="Training epochs")
+    parser.add_argument(
+        "--prediction-horizon", type=int, default=5, help="Prediction horizon"
+    )
+    parser.add_argument(
+        "--config", default="training/config/model_config.yaml", help="Config file"
+    )
+    parser.add_argument("--output", default="models", help="Output directory")
+    parser.add_argument("--debug", action="store_true", help="Debug mode")
+
     args = parser.parse_args()
-    
+
     print("🎯 ELVIS Training - Vault-Free Mode")
     print("=" * 40)
     print("🔓 Vault authentication: DISABLED")
     print("📝 Using environment variables only")
     print("🧪 Safe for training and testing")
     print()
-    
+
     # Create output directory
     os.makedirs(args.output, exist_ok=True)
-    
+
     # Run training
     run_training(args)
-    
+
     print("\n💡 Next steps:")
     print("   - Check model outputs in models/")
     print("   - Review logs for training progress")
     print("   - Test models with paper trading")
+
 
 if __name__ == "__main__":
     main()

--- a/train_with_llm.py
+++ b/train_with_llm.py
@@ -4,15 +4,16 @@ LLM-Enhanced Training Script for ELVIS Trading System
 Integrates local LLM analysis directly into the training pipeline
 """
 
-import os
-import sys
-import logging
 import argparse
 import asyncio
-import numpy as np
-import pandas as pd
+import logging
+import os
+import sys
 from datetime import datetime
 from pathlib import Path
+
+import numpy as np
+import pandas as pd
 
 # Add project root to Python path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -20,62 +21,66 @@ sys.path.insert(0, str(Path(__file__).parent))
 from training.llm_enhanced_trainer import LLMEnhancedTrainer, create_llm_config_from_env
 from utils.logging_utils import setup_logger
 
+
 def setup_llm_environment():
     """Setup environment variables for LLM integration"""
-    
+
     # LLM configuration
-    if not os.getenv('ELVIS_LLM_PROVIDER'):
-        os.environ['ELVIS_LLM_PROVIDER'] = 'local'
-    if not os.getenv('ELVIS_LLM_MODEL'):
-        os.environ['ELVIS_LLM_MODEL'] = 'openai/gpt-oss-20b'
-    if not os.getenv('ELVIS_LLM_BASE_URL'):
-        os.environ['ELVIS_LLM_BASE_URL'] = 'http://localhost:1234/v1'
-    if not os.getenv('ELVIS_LLM_TEMPERATURE'):
-        os.environ['ELVIS_LLM_TEMPERATURE'] = '0.3'
-    if not os.getenv('ELVIS_LLM_TIMEOUT'):
-        os.environ['ELVIS_LLM_TIMEOUT'] = '30'
-    
+    if not os.getenv("ELVIS_LLM_PROVIDER"):
+        os.environ["ELVIS_LLM_PROVIDER"] = "local"
+    if not os.getenv("ELVIS_LLM_MODEL"):
+        os.environ["ELVIS_LLM_MODEL"] = "openai/gpt-oss-20b"
+    if not os.getenv("ELVIS_LLM_BASE_URL"):
+        os.environ["ELVIS_LLM_BASE_URL"] = "http://localhost:1234/v1"
+    if not os.getenv("ELVIS_LLM_TEMPERATURE"):
+        os.environ["ELVIS_LLM_TEMPERATURE"] = "0.3"
+    if not os.getenv("ELVIS_LLM_TIMEOUT"):
+        os.environ["ELVIS_LLM_TIMEOUT"] = "30"
+
     # Training configuration
-    os.environ['VAULT_ENABLED'] = 'false'
-    os.environ['USE_VAULT'] = 'false'
-    os.environ['VAULT_AVAILABLE'] = 'false'
-    
+    os.environ["VAULT_ENABLED"] = "false"
+    os.environ["USE_VAULT"] = "false"
+    os.environ["VAULT_AVAILABLE"] = "false"
+
     # Safe training credentials
-    os.environ['BINANCE_API_KEY'] = 'training_with_llm_key'
-    os.environ['BINANCE_API_SECRET'] = 'training_with_llm_secret'
+    os.environ["BINANCE_API_KEY"] = "training_with_llm_key"
+    os.environ["BINANCE_API_SECRET"] = "training_with_llm_secret"
+
 
 def load_training_data(limit: int = 1000) -> pd.DataFrame:
     """Load and prepare training data"""
-    
-    logger = setup_logger('data_loader')
+
+    logger = setup_logger("data_loader")
     logger.info(f"📊 Loading training data (limit: {limit})...")
-    
+
     try:
         # Try to load from multiple sources, prioritizing real trading data
         data_sources = [
-            'data/processed/trade_history/trade_features.csv',  # Real trading data
-            'data/processed/trade_features.csv',
-            'data/processed/trade_data.csv',
-            'data/trade_data.csv'
+            "data/processed/trade_history/trade_features.csv",  # Real trading data
+            "data/processed/trade_features.csv",
+            "data/processed/trade_data.csv",
+            "data/trade_data.csv",
         ]
-        
+
         df = None
         for source in data_sources:
             if os.path.exists(source):
                 logger.info(f"📂 Loading data from: {source}")
                 df = pd.read_csv(source)
                 break
-        
+
         if df is None:
             # Generate synthetic data for testing
-            logger.warning("⚠️ No data files found - generating synthetic data for testing")
+            logger.warning(
+                "⚠️ No data files found - generating synthetic data for testing"
+            )
             df = generate_synthetic_data(limit)
         else:
             # We have real data - convert to OHLCV format if needed
             df = prepare_real_trading_data(df, logger)
-            
+
             # Try to load corresponding targets if available
-            targets_file = source.replace('trade_features.csv', 'trade_targets.csv')
+            targets_file = source.replace("trade_features.csv", "trade_targets.csv")
             if os.path.exists(targets_file):
                 logger.info(f"📊 Loading targets from: {targets_file}")
                 targets_df = pd.read_csv(targets_file)
@@ -85,203 +90,225 @@ def load_training_data(limit: int = 1000) -> pd.DataFrame:
                         df[col] = targets_df[col].values
                     logger.info(f"✅ Merged {len(targets_df.columns)} target columns")
                 else:
-                    logger.warning(f"⚠️ Target file length mismatch: {len(targets_df)} vs {len(df)}")
+                    logger.warning(
+                        f"⚠️ Target file length mismatch: {len(targets_df)} vs {len(df)}"
+                    )
             else:
-                logger.info("📊 No target file found, will create targets from price data")
-        
+                logger.info(
+                    "📊 No target file found, will create targets from price data"
+                )
+
         # Limit data if requested
         if limit > 0 and len(df) > limit:
             df = df.tail(limit)  # Use most recent data
             logger.info(f"📏 Limited data to most recent {limit} samples")
-        
+
         # Ensure required columns exist
-        required_columns = ['open', 'high', 'low', 'close', 'volume']
+        required_columns = ["open", "high", "low", "close", "volume"]
         missing_columns = [col for col in required_columns if col not in df.columns]
-        
+
         if missing_columns:
             logger.warning(f"⚠️ Some OHLCV columns missing: {missing_columns}")
             # Add missing columns with reasonable defaults
             for col in missing_columns:
-                if col == 'volume':
-                    df[col] = df.get('quantity', 1000000)  # Use quantity or default
+                if col == "volume":
+                    df[col] = df.get("quantity", 1000000)  # Use quantity or default
                 else:
-                    df[col] = df.get('price', df.get('close', 65000))  # Use price as fallback
-        
+                    df[col] = df.get(
+                        "price", df.get("close", 65000)
+                    )  # Use price as fallback
+
         # Add technical indicators if missing
         df = add_technical_indicators(df)
-        
+
         logger.info(f"✅ Loaded {len(df)} samples with {len(df.columns)} features")
         return df
-        
+
     except Exception as e:
         logger.error(f"❌ Failed to load training data: {e}")
         raise
 
+
 def prepare_real_trading_data(df: pd.DataFrame, logger) -> pd.DataFrame:
     """Convert real trading data to OHLCV format for analysis"""
-    
+
     logger.info("🔄 Converting real trading data to OHLCV format...")
-    
+
     # Create OHLCV columns from trading data
-    if 'price' in df.columns:
-        df['open'] = df['price'].shift(1).fillna(df['price'])
-        df['high'] = df[['open', 'price']].max(axis=1) * 1.002  # Small spread
-        df['low'] = df[['open', 'price']].min(axis=1) * 0.998
-        df['close'] = df['price']
-    
-    if 'quantity' in df.columns:
-        df['volume'] = df['quantity'] * df.get('price', 65000)
+    if "price" in df.columns:
+        df["open"] = df["price"].shift(1).fillna(df["price"])
+        df["high"] = df[["open", "price"]].max(axis=1) * 1.002  # Small spread
+        df["low"] = df[["open", "price"]].min(axis=1) * 0.998
+        df["close"] = df["price"]
+
+    if "quantity" in df.columns:
+        df["volume"] = df["quantity"] * df.get("price", 65000)
     else:
-        df['volume'] = 1000000  # Default volume
-    
+        df["volume"] = 1000000  # Default volume
+
     # Ensure we have basic price movement data
-    if 'price_change' not in df.columns and 'close' in df.columns:
-        df['price_change_pct'] = df['close'].pct_change().fillna(0)
-    elif 'price_change' in df.columns:
-        df['price_change_pct'] = df['price_change'] / df['close'] 
-    
+    if "price_change" not in df.columns and "close" in df.columns:
+        df["price_change_pct"] = df["close"].pct_change().fillna(0)
+    elif "price_change" in df.columns:
+        df["price_change_pct"] = df["price_change"] / df["close"]
+
     # Add volatility if missing
-    if 'price_volatility' not in df.columns:
-        df['volatility'] = df['price_change_pct'].rolling(20).std() * 100
+    if "price_volatility" not in df.columns:
+        df["volatility"] = df["price_change_pct"].rolling(20).std() * 100
     else:
-        df['volatility'] = df['price_volatility']
-    
+        df["volatility"] = df["price_volatility"]
+
     logger.info(f"✅ Converted to OHLCV format with {len(df.columns)} features")
     return df
 
+
 def generate_synthetic_data(num_samples: int) -> pd.DataFrame:
     """Generate synthetic market data for testing"""
-    
+
     # Generate realistic-looking OHLCV data
     base_price = 65000
-    timestamps = pd.date_range(start='2024-01-01', periods=num_samples, freq='1H')
-    
+    timestamps = pd.date_range(start="2024-01-01", periods=num_samples, freq="1H")
+
     # Random walk for price
     returns = np.random.normal(0, 0.002, num_samples)  # 0.2% hourly volatility
     prices = base_price * np.exp(np.cumsum(returns))
-    
+
     # Generate OHLCV
     data = []
     for i, (timestamp, close) in enumerate(zip(timestamps, prices)):
         # Add some realistic intraday movement
         high_factor = 1 + abs(np.random.normal(0, 0.005))
         low_factor = 1 - abs(np.random.normal(0, 0.005))
-        
-        open_price = prices[i-1] if i > 0 else close
+
+        open_price = prices[i - 1] if i > 0 else close
         high_price = max(open_price, close) * high_factor
         low_price = min(open_price, close) * low_factor
         volume = np.random.uniform(500000, 2000000)
-        
-        data.append({
-            'timestamp': timestamp,
-            'open': open_price,
-            'high': high_price,
-            'low': low_price,
-            'close': close,
-            'volume': volume
-        })
-    
+
+        data.append(
+            {
+                "timestamp": timestamp,
+                "open": open_price,
+                "high": high_price,
+                "low": low_price,
+                "close": close,
+                "volume": volume,
+            }
+        )
+
     df = pd.DataFrame(data)
     return df
 
+
 def add_technical_indicators(df: pd.DataFrame) -> pd.DataFrame:
     """Add technical indicators to the dataset"""
-    
-    logger = setup_logger('tech_indicators')
+
+    logger = setup_logger("tech_indicators")
     logger.info("📈 Computing technical indicators...")
-    
+
     try:
         # Price-based indicators
-        df['price_change_pct'] = df['close'].pct_change().fillna(0)
-        df['volatility'] = df['price_change_pct'].rolling(24).std() * 100  # 24-hour rolling volatility
-        
+        df["price_change_pct"] = df["close"].pct_change().fillna(0)
+        df["volatility"] = (
+            df["price_change_pct"].rolling(24).std() * 100
+        )  # 24-hour rolling volatility
+
         # Moving averages
-        df['sma_20'] = df['close'].rolling(20).mean()
-        df['sma_50'] = df['close'].rolling(50).mean()
-        df['ema_12'] = df['close'].ewm(span=12).mean()
-        df['ema_26'] = df['close'].ewm(span=26).mean()
-        
+        df["sma_20"] = df["close"].rolling(20).mean()
+        df["sma_50"] = df["close"].rolling(50).mean()
+        df["ema_12"] = df["close"].ewm(span=12).mean()
+        df["ema_26"] = df["close"].ewm(span=26).mean()
+
         # RSI
-        delta = df['close'].diff()
+        delta = df["close"].diff()
         gain = (delta.where(delta > 0, 0)).rolling(14).mean()
         loss = (-delta.where(delta < 0, 0)).rolling(14).mean()
         rs = gain / loss
-        df['rsi'] = 100 - (100 / (1 + rs))
-        
+        df["rsi"] = 100 - (100 / (1 + rs))
+
         # MACD
-        df['macd'] = df['ema_12'] - df['ema_26']
-        df['macd_signal'] = df['macd'].ewm(span=9).mean()
-        
+        df["macd"] = df["ema_12"] - df["ema_26"]
+        df["macd_signal"] = df["macd"].ewm(span=9).mean()
+
         # Bollinger Bands
         bb_window = 20
         bb_std = 2
-        bb_middle = df['close'].rolling(bb_window).mean()
-        bb_std_dev = df['close'].rolling(bb_window).std()
-        df['bb_upper'] = bb_middle + (bb_std_dev * bb_std)
-        df['bb_lower'] = bb_middle - (bb_std_dev * bb_std)
-        df['bb_middle'] = bb_middle
-        
+        bb_middle = df["close"].rolling(bb_window).mean()
+        bb_std_dev = df["close"].rolling(bb_window).std()
+        df["bb_upper"] = bb_middle + (bb_std_dev * bb_std)
+        df["bb_lower"] = bb_middle - (bb_std_dev * bb_std)
+        df["bb_middle"] = bb_middle
+
         # Volume indicators
-        df['volume_sma'] = df['volume'].rolling(20).mean()
-        df['volume_ratio'] = df['volume'] / df['volume_sma']
-        
+        df["volume_sma"] = df["volume"].rolling(20).mean()
+        df["volume_ratio"] = df["volume"] / df["volume_sma"]
+
         # Fill NaN values
-        df = df.fillna(method='ffill').fillna(0)
-        
+        df = df.fillna(method="ffill").fillna(0)
+
         logger.info(f"✅ Added technical indicators: {len(df.columns)} total features")
         return df
-        
+
     except Exception as e:
         logger.error(f"❌ Failed to compute technical indicators: {e}")
         raise
 
+
 def create_training_targets(df: pd.DataFrame, horizon: int = 5) -> pd.DataFrame:
     """Create training targets for prediction"""
-    
-    logger = setup_logger('targets')
+
+    logger = setup_logger("targets")
     logger.info(f"🎯 Creating training targets (horizon: {horizon} periods)...")
-    
+
     # Check if we have existing targets from real trading data
-    if 'future_profitable' in df.columns:
+    if "future_profitable" in df.columns:
         logger.info("📊 Using existing real trading targets")
-        df['target_classification'] = df['future_profitable'].astype(int)
-        if 'future_pnl' in df.columns:
-            df['target_regression'] = df['future_pnl'] / 1000.0  # Normalize PnL
+        df["target_classification"] = df["future_profitable"].astype(int)
+        if "future_pnl" in df.columns:
+            df["target_regression"] = df["future_pnl"] / 1000.0  # Normalize PnL
         else:
-            df['target_regression'] = df['future_price_up'].astype(float) - 0.5  # Convert to [-0.5, 0.5]
+            df["target_regression"] = (
+                df["future_price_up"].astype(float) - 0.5
+            )  # Convert to [-0.5, 0.5]
     else:
         logger.info("🔄 Creating new prediction targets from price data")
         # Future price movement prediction
-        df['future_price'] = df['close'].shift(-horizon)
-        df['price_direction'] = (df['future_price'] > df['close']).astype(int)
-        df['price_change_future'] = (df['future_price'] - df['close']) / df['close']
-        
+        df["future_price"] = df["close"].shift(-horizon)
+        df["price_direction"] = (df["future_price"] > df["close"]).astype(int)
+        df["price_change_future"] = (df["future_price"] - df["close"]) / df["close"]
+
         # Classification target: 1 if price goes up more than 0.5%, 0 otherwise
-        df['target_classification'] = ((df['price_change_future'] > 0.005).astype(int))
-        
+        df["target_classification"] = (df["price_change_future"] > 0.005).astype(int)
+
         # Regression target: normalized price change
-        df['target_regression'] = df['price_change_future']
-        
+        df["target_regression"] = df["price_change_future"]
+
         # Remove rows without future data
         df = df[:-horizon]
-    
+
     # Ensure targets are clean
-    df = df.dropna(subset=['target_classification', 'target_regression'])
-    
+    df = df.dropna(subset=["target_classification", "target_regression"])
+
     logger.info(f"✅ Created targets for {len(df)} samples")
-    logger.info(f"   Classification distribution: {df['target_classification'].value_counts().to_dict()}")
-    logger.info(f"   Regression target range: [{df['target_regression'].min():.6f}, {df['target_regression'].max():.6f}]")
-    
+    logger.info(
+        f"   Classification distribution: {df['target_classification'].value_counts().to_dict()}"
+    )
+    logger.info(
+        f"   Regression target range: [{df['target_regression'].min():.6f}, {df['target_regression'].max():.6f}]"
+    )
+
     return df
 
-async def run_llm_enhanced_training(limit: int, epochs: int, horizon: int, 
-                                  enable_llm: bool, debug: bool):
+
+async def run_llm_enhanced_training(
+    limit: int, epochs: int, horizon: int, enable_llm: bool, debug: bool
+):
     """Run the complete LLM-enhanced training pipeline"""
-    
+
     # Setup logging
     log_level = logging.DEBUG if debug else logging.INFO
-    logger = setup_logger('llm_training', log_level=log_level)
-    
+    logger = setup_logger("llm_training", log_level=log_level)
+
     logger.info("🚀 Starting LLM-Enhanced Training Pipeline")
     logger.info("=" * 60)
     logger.info(f"📊 Configuration:")
@@ -290,16 +317,16 @@ async def run_llm_enhanced_training(limit: int, epochs: int, horizon: int,
     logger.info(f"   Prediction Horizon: {horizon}")
     logger.info(f"   LLM Enabled: {enable_llm}")
     logger.info(f"   Debug Mode: {debug}")
-    
+
     try:
         # 1. Load and prepare data
         logger.info("\n📂 Step 1: Loading training data...")
         df = load_training_data(limit)
-        
+
         # 2. Create targets
         logger.info("\n🎯 Step 2: Creating training targets...")
         df = create_training_targets(df, horizon)
-        
+
         # 3. LLM enhancement
         if enable_llm:
             logger.info("\n🧠 Step 3: LLM Feature Enhancement...")
@@ -307,197 +334,211 @@ async def run_llm_enhanced_training(limit: int, epochs: int, horizon: int,
             logger.info(f"   LLM Provider: {llm_config.provider}")
             logger.info(f"   LLM Model: {llm_config.model}")
             logger.info(f"   LLM URL: {llm_config.base_url}")
-            
+
             # Create LLM-enhanced trainer
             llm_trainer = LLMEnhancedTrainer(
-                llm_config=llm_config,
-                enable_llm=True,
-                cache_llm_responses=True
+                llm_config=llm_config, enable_llm=True, cache_llm_responses=True
             )
-            
+
             # Load existing cache if available
-            cache_file = 'llm_training_cache.json'
+            cache_file = "llm_training_cache.json"
             if os.path.exists(cache_file):
                 llm_trainer.load_llm_cache(cache_file)
-            
+
             # Enhance data with LLM features (process in small batches)
             batch_size = 5 if len(df) > 100 else 2
             logger.info(f"   Processing in batches of {batch_size}")
-            
+
             df = llm_trainer.prepare_llm_features(df, batch_size=batch_size)
-            
+
             # Save cache for future runs
             llm_trainer.save_llm_cache(cache_file)
-            
+
         else:
             logger.info("\n📊 Step 3: Skipping LLM enhancement (disabled)")
-        
+
         # 4. Prepare features and targets
         logger.info("\n🔧 Step 4: Preparing final dataset...")
-        
+
         # Select feature columns (exclude metadata columns and string columns)
-        exclude_columns = ['timestamp', 'future_price', 'price_change_future', 'side']
-        
+        exclude_columns = ["timestamp", "future_price", "price_change_future", "side"]
+
         # Get only numeric columns for training
         feature_columns = []
         for col in df.columns:
-            if (col not in exclude_columns 
-                and not col.startswith('target_') 
-                and not col.startswith('future_')):
+            if (
+                col not in exclude_columns
+                and not col.startswith("target_")
+                and not col.startswith("future_")
+            ):
                 try:
                     # Test if column is numeric
-                    pd.to_numeric(df[col], errors='raise')
+                    pd.to_numeric(df[col], errors="raise")
                     feature_columns.append(col)
                 except (ValueError, TypeError):
                     logger.debug(f"Skipping non-numeric column: {col}")
-        
+
         logger.info(f"   Selected {len(feature_columns)} numeric feature columns")
-        
+
         # Clean the feature data
         X_df = df[feature_columns].copy()
-        
+
         # Replace infinity values
         X_df = X_df.replace([np.inf, -np.inf], np.nan)
-        
+
         # Fill NaN values with column medians
         X_df = X_df.fillna(X_df.median())
-        
+
         # Final check for any remaining NaN/inf values
         if X_df.isnull().any().any():
             logger.warning("⚠️ Still have NaN values, filling with 0")
             X_df = X_df.fillna(0)
-        
+
         if not np.isfinite(X_df.values).all():
-            logger.warning("⚠️ Still have infinite values, clipping to reasonable range")
+            logger.warning(
+                "⚠️ Still have infinite values, clipping to reasonable range"
+            )
             X_df = X_df.clip(-1e10, 1e10)
-        
+
         X = X_df.values
-        y_classification = df['target_classification'].values
-        y_regression = df['target_regression'].values
-        
+        y_classification = df["target_classification"].values
+        y_regression = df["target_regression"].values
+
         logger.info(f"   Features shape: {X.shape}")
         logger.info(f"   Classification targets: {len(y_classification)}")
         logger.info(f"   Regression targets: {len(y_regression)}")
-        
+
         if enable_llm:
-            llm_features = [col for col in feature_columns if col.startswith('llm_')]
+            llm_features = [col for col in feature_columns if col.startswith("llm_")]
             logger.info(f"   LLM-derived features: {len(llm_features)}")
             if debug:
                 logger.debug(f"   LLM features: {llm_features}")
-        
+
         # 5. Train models
         logger.info("\n🏗️ Step 5: Training models...")
-        
-        from sklearn.model_selection import train_test_split
+
         from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-        from sklearn.metrics import accuracy_score, classification_report, mean_squared_error
-        from sklearn.preprocessing import StandardScaler
-        
-        # Split data
-        X_train, X_test, y_class_train, y_class_test, y_reg_train, y_reg_test = train_test_split(
-            X, y_classification, y_regression, test_size=0.2, random_state=42
+        from sklearn.metrics import (
+            accuracy_score,
+            classification_report,
+            mean_squared_error,
         )
-        
+        from sklearn.model_selection import train_test_split
+        from sklearn.preprocessing import StandardScaler
+
+        # Split data
+        X_train, X_test, y_class_train, y_class_test, y_reg_train, y_reg_test = (
+            train_test_split(
+                X, y_classification, y_regression, test_size=0.2, random_state=42
+            )
+        )
+
         # Scale features
         scaler = StandardScaler()
         X_train_scaled = scaler.fit_transform(X_train)
         X_test_scaled = scaler.transform(X_test)
-        
+
         # Train classification model
         logger.info("   Training classification model...")
         clf = RandomForestClassifier(n_estimators=100, random_state=42)
         clf.fit(X_train_scaled, y_class_train)
-        
+
         # Evaluate classification
         y_pred_class = clf.predict(X_test_scaled)
         class_accuracy = accuracy_score(y_class_test, y_pred_class)
         logger.info(f"   Classification Accuracy: {class_accuracy:.4f}")
-        
+
         # Train regression model
         logger.info("   Training regression model...")
         regressor = RandomForestRegressor(n_estimators=100, random_state=42)
         regressor.fit(X_train_scaled, y_reg_train)
-        
+
         # Evaluate regression
         y_pred_reg = regressor.predict(X_test_scaled)
         reg_mse = mean_squared_error(y_reg_test, y_pred_reg)
         logger.info(f"   Regression MSE: {reg_mse:.6f}")
-        
+
         # Feature importance (if debug mode)
         if debug and enable_llm:
             logger.debug("\n🔍 Feature Importance Analysis:")
             feature_importance = clf.feature_importances_
             feature_names = feature_columns
-            
+
             # Sort by importance
             importance_data = list(zip(feature_names, feature_importance))
             importance_data.sort(key=lambda x: x[1], reverse=True)
-            
+
             logger.debug("   Top 10 Most Important Features:")
             for i, (feature, importance) in enumerate(importance_data[:10]):
-                marker = "🧠" if feature.startswith('llm_') else "📊"
+                marker = "🧠" if feature.startswith("llm_") else "📊"
                 logger.debug(f"   {i+1:2d}. {marker} {feature}: {importance:.4f}")
-        
+
         # 6. Save results
         logger.info("\n💾 Step 6: Saving results...")
-        
+
         # Create models directory
-        models_dir = Path('models')
+        models_dir = Path("models")
         models_dir.mkdir(exist_ok=True)
-        
+
         # Save models
         import joblib
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
         model_files = {
-            'classifier': f'models/llm_enhanced_classifier_{timestamp}.joblib',
-            'regressor': f'models/llm_enhanced_regressor_{timestamp}.joblib',
-            'scaler': f'models/llm_enhanced_scaler_{timestamp}.joblib'
+            "classifier": f"models/llm_enhanced_classifier_{timestamp}.joblib",
+            "regressor": f"models/llm_enhanced_regressor_{timestamp}.joblib",
+            "scaler": f"models/llm_enhanced_scaler_{timestamp}.joblib",
         }
-        
-        joblib.dump(clf, model_files['classifier'])
-        joblib.dump(regressor, model_files['regressor'])
-        joblib.dump(scaler, model_files['scaler'])
-        
+
+        joblib.dump(clf, model_files["classifier"])
+        joblib.dump(regressor, model_files["regressor"])
+        joblib.dump(scaler, model_files["scaler"])
+
         logger.info(f"   Models saved:")
         for model_type, filepath in model_files.items():
             logger.info(f"     {model_type}: {filepath}")
-        
+
         # Save training metadata
         metadata = {
-            'timestamp': datetime.now().isoformat(),
-            'training_config': {
-                'limit': limit,
-                'epochs': epochs,
-                'horizon': horizon,
-                'llm_enabled': enable_llm
+            "timestamp": datetime.now().isoformat(),
+            "training_config": {
+                "limit": limit,
+                "epochs": epochs,
+                "horizon": horizon,
+                "llm_enabled": enable_llm,
             },
-            'data_info': {
-                'total_samples': len(df),
-                'total_features': len(feature_columns),
-                'llm_features': len([col for col in feature_columns if col.startswith('llm_')]) if enable_llm else 0
+            "data_info": {
+                "total_samples": len(df),
+                "total_features": len(feature_columns),
+                "llm_features": (
+                    len([col for col in feature_columns if col.startswith("llm_")])
+                    if enable_llm
+                    else 0
+                ),
             },
-            'model_performance': {
-                'classification_accuracy': float(class_accuracy),
-                'regression_mse': float(reg_mse)
+            "model_performance": {
+                "classification_accuracy": float(class_accuracy),
+                "regression_mse": float(reg_mse),
             },
-            'model_files': model_files
+            "model_files": model_files,
         }
-        
+
         if enable_llm:
-            metadata['llm_config'] = {
-                'provider': llm_config.provider,
-                'model': llm_config.model,
-                'base_url': llm_config.base_url
+            metadata["llm_config"] = {
+                "provider": llm_config.provider,
+                "model": llm_config.model,
+                "base_url": llm_config.base_url,
             }
-        
-        metadata_file = f'models/training_metadata_{timestamp}.json'
-        with open(metadata_file, 'w') as f:
+
+        metadata_file = f"models/training_metadata_{timestamp}.json"
+        with open(metadata_file, "w") as f:
             import json
+
             json.dump(metadata, f, indent=2)
-        
+
         logger.info(f"   Metadata saved: {metadata_file}")
-        
+
         # 7. Summary
         logger.info("\n🎉 Training Complete!")
         logger.info("=" * 60)
@@ -505,46 +546,58 @@ async def run_llm_enhanced_training(limit: int, epochs: int, horizon: int,
         logger.info(f"✅ Regression MSE: {reg_mse:.6f}")
         logger.info(f"✅ Total Features Used: {len(feature_columns)}")
         if enable_llm:
-            llm_count = len([col for col in feature_columns if col.startswith('llm_')])
+            llm_count = len([col for col in feature_columns if col.startswith("llm_")])
             logger.info(f"🧠 LLM Features Used: {llm_count}")
-        
+
         logger.info(f"📁 Results saved in: models/")
         logger.info(f"📊 Training metadata: {metadata_file}")
-        
+
         return True
-        
+
     except Exception as e:
         logger.error(f"❌ Training failed: {e}")
         if debug:
             import traceback
+
             logger.error(f"Full traceback:\n{traceback.format_exc()}")
         return False
 
+
 def main():
     """Main training function"""
-    
-    parser = argparse.ArgumentParser(description='LLM-Enhanced ELVIS Training')
-    parser.add_argument('--limit', type=int, default=1000, 
-                       help='Maximum number of samples to use')
-    parser.add_argument('--epochs', type=int, default=20,
-                       help='Number of training epochs')
-    parser.add_argument('--prediction-horizon', type=int, default=5,
-                       help='Prediction horizon in periods')
-    parser.add_argument('--enable-llm', action='store_true', default=True,
-                       help='Enable LLM feature enhancement')
-    parser.add_argument('--disable-llm', action='store_true',
-                       help='Disable LLM feature enhancement')
-    parser.add_argument('--debug', action='store_true',
-                       help='Enable debug logging')
-    
+
+    parser = argparse.ArgumentParser(description="LLM-Enhanced ELVIS Training")
+    parser.add_argument(
+        "--limit", type=int, default=1000, help="Maximum number of samples to use"
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=20, help="Number of training epochs"
+    )
+    parser.add_argument(
+        "--prediction-horizon",
+        type=int,
+        default=5,
+        help="Prediction horizon in periods",
+    )
+    parser.add_argument(
+        "--enable-llm",
+        action="store_true",
+        default=True,
+        help="Enable LLM feature enhancement",
+    )
+    parser.add_argument(
+        "--disable-llm", action="store_true", help="Disable LLM feature enhancement"
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
     args = parser.parse_args()
-    
+
     # Handle LLM enable/disable flags
     enable_llm = args.enable_llm and not args.disable_llm
-    
+
     # Setup environment
     setup_llm_environment()
-    
+
     print("🧠 LLM-Enhanced ELVIS Training")
     print("=" * 40)
     print(f"📊 Samples: {args.limit}")
@@ -552,23 +605,25 @@ def main():
     print(f"🎯 Horizon: {args.prediction_horizon}")
     print(f"🧠 LLM Enabled: {enable_llm}")
     print(f"🐛 Debug: {args.debug}")
-    
+
     if enable_llm:
         print(f"🤖 LLM Model: {os.getenv('ELVIS_LLM_MODEL')}")
         print(f"🔗 LLM URL: {os.getenv('ELVIS_LLM_BASE_URL')}")
-    
+
     print()
-    
+
     # Run training
     try:
-        success = asyncio.run(run_llm_enhanced_training(
-            limit=args.limit,
-            epochs=args.epochs,
-            horizon=args.prediction_horizon,
-            enable_llm=enable_llm,
-            debug=args.debug
-        ))
-        
+        success = asyncio.run(
+            run_llm_enhanced_training(
+                limit=args.limit,
+                epochs=args.epochs,
+                horizon=args.prediction_horizon,
+                enable_llm=enable_llm,
+                debug=args.debug,
+            )
+        )
+
         if success:
             print("\n🎉 Training completed successfully!")
             if enable_llm:
@@ -577,13 +632,14 @@ def main():
         else:
             print("\n❌ Training failed!")
             sys.exit(1)
-            
+
     except KeyboardInterrupt:
         print("\n👋 Training interrupted by user")
         sys.exit(1)
     except Exception as e:
         print(f"\n❌ Training error: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/train_with_postgres.py
+++ b/train_with_postgres.py
@@ -4,110 +4,118 @@ Training script that works with existing PostgreSQL setup
 No Vault required - uses your existing databases
 """
 
-import os
-import sys
-import subprocess
 import argparse
 import logging
+import os
+import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
+
 import psycopg2
+
 
 def check_postgres_connection():
     """Check PostgreSQL connection and find the right database"""
     print("🗄️  Checking PostgreSQL connection...")
-    
+
     # Try different database configurations
     configs = [
         {
-            'host': 'localhost',
-            'port': 5432,
-            'user': 'maxime',
-            'password': '',  # Try without password first
-            'dbname': 'elvis_trading'
+            "host": "localhost",
+            "port": 5432,
+            "user": "maxime",
+            "password": "",  # Try without password first
+            "dbname": "elvis_trading",
         },
         {
-            'host': 'localhost', 
-            'port': 5432,
-            'user': 'postgres',
-            'password': 'elvis_password',
-            'dbname': 'elvis_trading'
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "elvis_password",
+            "dbname": "elvis_trading",
         },
         {
-            'host': 'localhost',
-            'port': 5432, 
-            'user': 'postgres',
-            'password': '',
-            'dbname': 'trading_bot'
-        }
+            "host": "localhost",
+            "port": 5432,
+            "user": "postgres",
+            "password": "",
+            "dbname": "trading_bot",
+        },
     ]
-    
+
     for config in configs:
         try:
             # Try to connect
             conn_str = f"host={config['host']} port={config['port']} dbname={config['dbname']} user={config['user']}"
-            if config['password']:
+            if config["password"]:
                 conn_str += f" password={config['password']}"
-                
+
             conn = psycopg2.connect(conn_str)
             cursor = conn.cursor()
-            
+
             # Check for trades table
             cursor.execute("""
                 SELECT COUNT(*) FROM information_schema.tables 
                 WHERE table_name IN ('trades', 'trade_history', 'paper_trades')
             """)
             table_count = cursor.fetchone()[0]
-            
+
             if table_count > 0:
                 # Get trade count
-                for table_name in ['trades', 'trade_history', 'paper_trades']:
+                for table_name in ["trades", "trade_history", "paper_trades"]:
                     try:
                         cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
                         trade_count = cursor.fetchone()[0]
-                        print(f"✅ Connected to {config['dbname']} - Found {trade_count} trades in {table_name}")
-                        
+                        print(
+                            f"✅ Connected to {config['dbname']} - Found {trade_count} trades in {table_name}"
+                        )
+
                         conn.close()
                         return config, table_name, trade_count
                     except:
                         continue
-            
+
             conn.close()
-            
+
         except Exception as e:
-            print(f"❌ Failed to connect with config {config['dbname']}: {str(e)[:50]}...")
+            print(
+                f"❌ Failed to connect with config {config['dbname']}: {str(e)[:50]}..."
+            )
             continue
-    
+
     print("❌ Could not find a working PostgreSQL connection with trade data")
     return None, None, 0
+
 
 def setup_postgres_environment(db_config):
     """Setup environment for PostgreSQL connection"""
     print("🔧 Setting up PostgreSQL environment...")
-    
+
     # Disable Vault
-    os.environ['VAULT_ENABLED'] = 'false'
-    os.environ['USE_VAULT'] = 'false'
-    
+    os.environ["VAULT_ENABLED"] = "false"
+    os.environ["USE_VAULT"] = "false"
+
     # Set database configuration
-    os.environ['POSTGRES_HOST'] = db_config['host']
-    os.environ['POSTGRES_PORT'] = str(db_config['port'])
-    os.environ['POSTGRES_USER'] = db_config['user']
-    os.environ['POSTGRES_PASSWORD'] = db_config.get('password', '')
-    os.environ['POSTGRES_DBNAME'] = db_config['dbname']
-    
+    os.environ["POSTGRES_HOST"] = db_config["host"]
+    os.environ["POSTGRES_PORT"] = str(db_config["port"])
+    os.environ["POSTGRES_USER"] = db_config["user"]
+    os.environ["POSTGRES_PASSWORD"] = db_config.get("password", "")
+    os.environ["POSTGRES_DBNAME"] = db_config["dbname"]
+
     # Set other required variables
-    os.environ['REDIS_HOST'] = 'localhost'
-    os.environ['REDIS_PORT'] = '6379'
-    os.environ['BINANCE_API_KEY'] = 'training_key'
-    os.environ['BINANCE_API_SECRET'] = 'training_secret'
-    
+    os.environ["REDIS_HOST"] = "localhost"
+    os.environ["REDIS_PORT"] = "6379"
+    os.environ["BINANCE_API_KEY"] = "training_key"
+    os.environ["BINANCE_API_SECRET"] = "training_secret"
+
     print(f"✅ Environment configured for database: {db_config['dbname']}")
+
 
 def create_sample_data_if_needed():
     """Create sample trade data if database is empty"""
     print("📊 Creating sample trade data for training...")
-    
+
     sample_script = """
 import pandas as pd
 import numpy as np
@@ -185,44 +193,47 @@ finally:
     if conn:
         conn.close()
 """
-    
-    with open('create_sample_trades.py', 'w') as f:
+
+    with open("create_sample_trades.py", "w") as f:
         f.write(sample_script)
-    
+
     try:
-        subprocess.run([sys.executable, 'create_sample_trades.py'], check=True)
+        subprocess.run([sys.executable, "create_sample_trades.py"], check=True)
         print("✅ Sample data created successfully")
     except Exception as e:
         print(f"❌ Failed to create sample data: {e}")
 
+
 def run_training_with_postgres(args, db_config, table_name):
     """Run training with PostgreSQL configuration"""
     print("🚀 Starting training with PostgreSQL...")
-    
+
     # Setup environment
     setup_postgres_environment(db_config)
-    
+
     # Set the table name for the training script to use
-    os.environ['POSTGRES_TABLE_NAME'] = table_name
-    
+    os.environ["POSTGRES_TABLE_NAME"] = table_name
+
     # Build command
     cmd_parts = [
         sys.executable,
-        'training/train_models.py',
-        '--include-trade-history',
-        '--config', args.config,
-        '--output', args.output,
+        "training/train_models.py",
+        "--include-trade-history",
+        "--config",
+        args.config,
+        "--output",
+        args.output,
     ]
-    
+
     if args.debug:
-        cmd_parts.append('--debug')
-        os.environ['LOG_LEVEL'] = 'DEBUG'
-    
+        cmd_parts.append("--debug")
+        os.environ["LOG_LEVEL"] = "DEBUG"
+
     # Set training parameters
-    os.environ['TRADE_LIMIT'] = str(args.limit)
-    os.environ['PREDICTION_HORIZON'] = str(args.prediction_horizon)
-    os.environ['TRAINING_EPOCHS'] = str(args.epochs)
-    
+    os.environ["TRADE_LIMIT"] = str(args.limit)
+    os.environ["PREDICTION_HORIZON"] = str(args.prediction_horizon)
+    os.environ["TRAINING_EPOCHS"] = str(args.epochs)
+
     print(f"📊 Training Configuration:")
     print(f"   Database: {db_config['dbname']} ({table_name})")
     print(f"   Trades: {args.limit} max")
@@ -230,55 +241,62 @@ def run_training_with_postgres(args, db_config, table_name):
     print(f"   Debug: {args.debug}")
     print(f"⏰ Started: {datetime.now().strftime('%H:%M:%S')}")
     print()
-    
+
     try:
         result = subprocess.run(cmd_parts, env=os.environ.copy())
-        
+
         if result.returncode == 0:
             print(f"\n✅ Training completed successfully!")
             print(f"🕒 Finished: {datetime.now().strftime('%H:%M:%S')}")
         else:
             print(f"\n❌ Training failed with code {result.returncode}")
-            
+
     except KeyboardInterrupt:
         print("\n⚠️  Training interrupted")
     except Exception as e:
         print(f"\n❌ Training error: {e}")
 
+
 def main():
     """Main function"""
-    parser = argparse.ArgumentParser(description='Train ELVIS with PostgreSQL')
-    parser.add_argument('--limit', type=int, default=1000, help='Max trades')
-    parser.add_argument('--epochs', type=int, default=10, help='Training epochs')
-    parser.add_argument('--prediction-horizon', type=int, default=5, help='Prediction horizon')
-    parser.add_argument('--config', default='training/config/model_config.yaml', help='Config')
-    parser.add_argument('--output', default='models', help='Output directory')
-    parser.add_argument('--debug', action='store_true', help='Debug mode')
-    parser.add_argument('--create-sample-data', action='store_true', help='Create sample data')
-    
+    parser = argparse.ArgumentParser(description="Train ELVIS with PostgreSQL")
+    parser.add_argument("--limit", type=int, default=1000, help="Max trades")
+    parser.add_argument("--epochs", type=int, default=10, help="Training epochs")
+    parser.add_argument(
+        "--prediction-horizon", type=int, default=5, help="Prediction horizon"
+    )
+    parser.add_argument(
+        "--config", default="training/config/model_config.yaml", help="Config"
+    )
+    parser.add_argument("--output", default="models", help="Output directory")
+    parser.add_argument("--debug", action="store_true", help="Debug mode")
+    parser.add_argument(
+        "--create-sample-data", action="store_true", help="Create sample data"
+    )
+
     args = parser.parse_args()
-    
+
     print("🎯 ELVIS Training - PostgreSQL Mode")
     print("=" * 40)
     print("🗄️  Using PostgreSQL database")
     print("🔓 Vault authentication: DISABLED")
     print()
-    
+
     # Check PostgreSQL connection
     db_config, table_name, trade_count = check_postgres_connection()
-    
+
     if not db_config:
         print("💡 No PostgreSQL connection found. Try:")
         print("   1. Start PostgreSQL: brew services start postgresql")
         print("   2. Check database exists: psql -l")
         print("   3. Create database: createdb elvis_trading")
         return
-    
+
     if trade_count == 0 and args.create_sample_data:
         create_sample_data_if_needed()
         # Recheck after creating data
         db_config, table_name, trade_count = check_postgres_connection()
-    
+
     if trade_count > 0:
         print(f"📈 Found {trade_count} trades - proceeding with training")
         os.makedirs(args.output, exist_ok=True)
@@ -286,6 +304,7 @@ def main():
     else:
         print("⚠️  No trade data found. Use --create-sample-data to generate test data")
         print("   python train_with_postgres.py --create-sample-data --debug")
+
 
 if __name__ == "__main__":
     main()

--- a/train_with_postgres_llm.py
+++ b/train_with_postgres_llm.py
@@ -3,196 +3,237 @@
 Train LLM-enhanced models using all available PostgreSQL paper trading data.
 """
 
+import argparse
 import os
 import sys
-import argparse
-import pandas as pd
-import numpy as np
-from typing import Dict, Any
+from typing import Any, Dict
 
+import numpy as np
+import pandas as pd
 from load_postgres_training_data import (
-    load_all_postgres_trades, 
-    postgres_trades_to_ohlcv, 
-    enhance_postgres_training_data
+    enhance_postgres_training_data,
+    load_all_postgres_trades,
+    postgres_trades_to_ohlcv,
 )
+
 from training.llm_enhanced_trainer import LLMEnhancedTrainer, create_llm_config_from_env
 from utils.logging_utils import setup_logger
 
+
 def setup_llm_environment():
     """Setup environment variables for LLM integration"""
-    
-    # LLM configuration
-    if not os.getenv('ELVIS_LLM_PROVIDER'):
-        os.environ['ELVIS_LLM_PROVIDER'] = 'local'
-    if not os.getenv('ELVIS_LLM_MODEL'):
-        os.environ['ELVIS_LLM_MODEL'] = 'openai/gpt-oss-20b'
-    if not os.getenv('ELVIS_LLM_BASE_URL'):
-        os.environ['ELVIS_LLM_BASE_URL'] = 'http://localhost:1234/v1'
-    if not os.getenv('ELVIS_LLM_TEMPERATURE'):
-        os.environ['ELVIS_LLM_TEMPERATURE'] = '0.3'
-    if not os.getenv('ELVIS_LLM_TIMEOUT'):
-        os.environ['ELVIS_LLM_TIMEOUT'] = '30'
-    
-    # Training configuration
-    os.environ['VAULT_ENABLED'] = 'false'
-    os.environ['USE_VAULT'] = 'false'
-    os.environ['VAULT_AVAILABLE'] = 'false'
-    
-    # Safe training credentials
-    os.environ['BINANCE_API_KEY'] = 'postgres_training_key'
-    os.environ['BINANCE_API_SECRET'] = 'postgres_training_secret'
 
-def load_postgres_training_data(include_test_trades: bool = True, max_trades: int = 0) -> pd.DataFrame:
+    # LLM configuration
+    if not os.getenv("ELVIS_LLM_PROVIDER"):
+        os.environ["ELVIS_LLM_PROVIDER"] = "local"
+    if not os.getenv("ELVIS_LLM_MODEL"):
+        os.environ["ELVIS_LLM_MODEL"] = "openai/gpt-oss-20b"
+    if not os.getenv("ELVIS_LLM_BASE_URL"):
+        os.environ["ELVIS_LLM_BASE_URL"] = "http://localhost:1234/v1"
+    if not os.getenv("ELVIS_LLM_TEMPERATURE"):
+        os.environ["ELVIS_LLM_TEMPERATURE"] = "0.3"
+    if not os.getenv("ELVIS_LLM_TIMEOUT"):
+        os.environ["ELVIS_LLM_TIMEOUT"] = "30"
+
+    # Training configuration
+    os.environ["VAULT_ENABLED"] = "false"
+    os.environ["USE_VAULT"] = "false"
+    os.environ["VAULT_AVAILABLE"] = "false"
+
+    # Safe training credentials
+    os.environ["BINANCE_API_KEY"] = "postgres_training_key"
+    os.environ["BINANCE_API_SECRET"] = "postgres_training_secret"
+
+
+def load_postgres_training_data(
+    include_test_trades: bool = True, max_trades: int = 0
+) -> pd.DataFrame:
     """Load and prepare all PostgreSQL training data"""
-    
-    logger = setup_logger('postgres_data_loader')
+
+    logger = setup_logger("postgres_data_loader")
     logger.info("🐘 Loading all paper trading data from PostgreSQL...")
-    
+
     try:
         # Load all trades from PostgreSQL
         trades_df = load_all_postgres_trades(include_test_trades=include_test_trades)
-        
+
         # Apply trades limit if specified
         if max_trades > 0 and len(trades_df) > max_trades:
-            logger.info(f"📏 Limiting to most recent {max_trades} trades (from {len(trades_df)} available)")
+            logger.info(
+                f"📏 Limiting to most recent {max_trades} trades (from {len(trades_df)} available)"
+            )
             trades_df = trades_df.tail(max_trades)
-        
+
         if trades_df.empty:
             logger.error("❌ No trades found in PostgreSQL!")
             return pd.DataFrame()
-        
+
         # Convert to OHLCV format
         ohlcv_df = postgres_trades_to_ohlcv(trades_df)
-        
+
         if ohlcv_df.empty:
             logger.error("❌ No OHLCV data generated!")
             return pd.DataFrame()
-        
+
         # Enhance with features and targets
         enhanced_df = enhance_postgres_training_data(ohlcv_df)
-        
+
         logger.info(f"✅ Prepared PostgreSQL training data:")
         logger.info(f"   📊 Original trades: {len(trades_df)}")
         logger.info(f"   📈 OHLCV periods: {len(ohlcv_df)}")
         logger.info(f"   🎯 Training samples: {len(enhanced_df)}")
-        logger.info(f"   📅 Date range: {enhanced_df['timestamp'].min()} to {enhanced_df['timestamp'].max()}")
-        
+        logger.info(
+            f"   📅 Date range: {enhanced_df['timestamp'].min()} to {enhanced_df['timestamp'].max()}"
+        )
+
         return enhanced_df
-        
+
     except Exception as e:
         logger.error(f"❌ Failed to load PostgreSQL training data: {e}")
         raise
 
+
 def create_training_targets(df: pd.DataFrame, horizon: int = 5) -> pd.DataFrame:
     """Create training targets based on prediction horizon"""
-    
-    logger = setup_logger('target_creator')
+
+    logger = setup_logger("target_creator")
     logger.info(f"🎯 Creating training targets (horizon: {horizon} periods)...")
-    
+
     if len(df) < horizon + 1:
         logger.warning(f"⚠️ Not enough data for horizon {horizon}")
         return df
-    
+
     # We already have basic targets, but let's enhance them with the specified horizon
     df = df.copy()
-    
+
     # Future price at specified horizon
-    df[f'future_price_{horizon}'] = df['close'].shift(-horizon)
-    df[f'future_return_{horizon}'] = (df[f'future_price_{horizon}'] / df['close']) - 1
-    
+    df[f"future_price_{horizon}"] = df["close"].shift(-horizon)
+    df[f"future_return_{horizon}"] = (df[f"future_price_{horizon}"] / df["close"]) - 1
+
     # Classification targets
-    df[f'target_up_{horizon}'] = (df[f'future_return_{horizon}'] > 0).astype(int)
-    df[f'target_profitable_{horizon}'] = (df[f'future_return_{horizon}'] > 0.001).astype(int)  # >0.1% profit
-    
+    df[f"target_up_{horizon}"] = (df[f"future_return_{horizon}"] > 0).astype(int)
+    df[f"target_profitable_{horizon}"] = (
+        df[f"future_return_{horizon}"] > 0.001
+    ).astype(
+        int
+    )  # >0.1% profit
+
     # Regression targets
-    df[f'target_return_{horizon}'] = df[f'future_return_{horizon}']
-    
+    df[f"target_return_{horizon}"] = df[f"future_return_{horizon}"]
+
     # Remove rows without future data
     df = df[:-horizon].copy()
-    
+
     # Use the horizon-specific targets as main targets
-    df['target_classification'] = df[f'target_up_{horizon}']
-    df['target_regression'] = df[f'target_return_{horizon}']
-    
+    df["target_classification"] = df[f"target_up_{horizon}"]
+    df["target_regression"] = df[f"target_return_{horizon}"]
+
     logger.info(f"✅ Created targets for {len(df)} samples")
-    logger.info(f"   Classification distribution: {dict(df['target_classification'].value_counts())}")
-    logger.info(f"   Regression target range: [{df['target_regression'].min():.6f}, {df['target_regression'].max():.6f}]")
-    
+    logger.info(
+        f"   Classification distribution: {dict(df['target_classification'].value_counts())}"
+    )
+    logger.info(
+        f"   Regression target range: [{df['target_regression'].min():.6f}, {df['target_regression'].max():.6f}]"
+    )
+
     return df
 
-def train_llm_enhanced_models(df: pd.DataFrame, epochs: int = 3, batch_size: int = 10, debug: bool = False, args=None):
+
+def train_llm_enhanced_models(
+    df: pd.DataFrame,
+    epochs: int = 3,
+    batch_size: int = 10,
+    debug: bool = False,
+    args=None,
+):
     """Train LLM-enhanced models on PostgreSQL data"""
-    
-    logger = setup_logger('llm_model_trainer')
+
+    logger = setup_logger("llm_model_trainer")
     logger.info(f"🧠 Training LLM-enhanced models on {len(df)} PostgreSQL samples...")
-    
+
     # Setup LLM trainer
     llm_config = create_llm_config_from_env()
     trainer = LLMEnhancedTrainer(llm_config)
-    
+
     # Load existing LLM cache if available
-    cache_file = 'postgres_llm_cache.json'
+    cache_file = "postgres_llm_cache.json"
     if os.path.exists(cache_file):
         trainer.load_llm_cache(cache_file)
         logger.info(f"📂 Loaded LLM cache from: {cache_file}")
-    
+
     # Generate LLM features
     logger.info("🧠 Generating LLM features...")
     enhanced_df = trainer.prepare_llm_features(df, batch_size=batch_size)
-    
+
     # Save LLM cache
     trainer.save_llm_cache(cache_file)
     logger.info(f"💾 Saved LLM cache to: {cache_file}")
-    
+
     # Prepare features and targets
-    feature_columns = [col for col in enhanced_df.columns 
-                      if col not in ['timestamp', 'symbol', 'target_classification', 'target_regression']
-                      and not col.startswith('future_')
-                      and not col.startswith('target_')]
-    
+    feature_columns = [
+        col
+        for col in enhanced_df.columns
+        if col
+        not in ["timestamp", "symbol", "target_classification", "target_regression"]
+        and not col.startswith("future_")
+        and not col.startswith("target_")
+    ]
+
     X = enhanced_df[feature_columns].fillna(0)
-    y_classification = enhanced_df['target_classification']
-    y_regression = enhanced_df['target_regression'].fillna(0)
-    
+    y_classification = enhanced_df["target_classification"]
+    y_regression = enhanced_df["target_regression"].fillna(0)
+
     # Remove infinite values
     X = X.replace([np.inf, -np.inf], np.nan).fillna(0)
     y_regression = y_regression.replace([np.inf, -np.inf], 0)
-    
+
     logger.info(f"📊 Training data prepared:")
-    logger.info(f"   Features: {len(feature_columns)} ({len([c for c in feature_columns if c.startswith('llm_')])} LLM features)")
+    logger.info(
+        f"   Features: {len(feature_columns)} ({len([c for c in feature_columns if c.startswith('llm_')])} LLM features)"
+    )
     logger.info(f"   Samples: {len(X)}")
     logger.info(f"   Classification targets: {len(y_classification)}")
     logger.info(f"   Regression targets: {len(y_regression)}")
-    
+
     if debug:
         logger.debug(f"   Feature columns: {feature_columns}")
-        logger.debug(f"   LLM features: {[c for c in feature_columns if c.startswith('llm_')]}")
-    
+        logger.debug(
+            f"   LLM features: {[c for c in feature_columns if c.startswith('llm_')]}"
+        )
+
     # Train models
     logger.info("🏗️ Training models...")
-    
-    from sklearn.model_selection import train_test_split
+
     from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
-    from sklearn.metrics import accuracy_score, classification_report, mean_squared_error
-    from sklearn.preprocessing import StandardScaler
-    
-    # Split data (80/20)
-    X_train, X_test, y_class_train, y_class_test, y_reg_train, y_reg_test = train_test_split(
-        X, y_classification, y_regression, test_size=0.2, random_state=42
+    from sklearn.metrics import (
+        accuracy_score,
+        classification_report,
+        mean_squared_error,
     )
-    
-    logger.info(f"📊 Data split: {len(X_train)} training, {len(X_test)} testing samples")
-    
+    from sklearn.model_selection import train_test_split
+    from sklearn.preprocessing import StandardScaler
+
+    # Split data (80/20)
+    X_train, X_test, y_class_train, y_class_test, y_reg_train, y_reg_test = (
+        train_test_split(
+            X, y_classification, y_regression, test_size=0.2, random_state=42
+        )
+    )
+
+    logger.info(
+        f"📊 Data split: {len(X_train)} training, {len(X_test)} testing samples"
+    )
+
     # Scale features
     scaler = StandardScaler()
     X_train_scaled = scaler.fit_transform(X_train)
     X_test_scaled = scaler.transform(X_test)
-    
+
     # Train classification model
     logger.info("   Training classification model...")
     # Scale n_estimators based on epochs (more epochs = more trees)
     n_estimators = min(500, max(100, epochs * 50))
-    
+
     classifier = RandomForestClassifier(
         n_estimators=n_estimators,
         max_depth=20,  # Deeper trees for more complex patterns
@@ -200,17 +241,17 @@ def train_llm_enhanced_models(df: pd.DataFrame, epochs: int = 3, batch_size: int
         min_samples_leaf=2,
         random_state=42,
         n_jobs=-1,
-        class_weight='balanced',
+        class_weight="balanced",
         bootstrap=True,
-        oob_score=True  # Out-of-bag scoring
+        oob_score=True,  # Out-of-bag scoring
     )
     classifier.fit(X_train_scaled, y_class_train)
-    
+
     # Evaluate classification
     class_pred = classifier.predict(X_test_scaled)
     class_accuracy = accuracy_score(y_class_test, class_pred)
     logger.info(f"   Classification Accuracy: {class_accuracy:.4f}")
-    
+
     # Train regression model
     logger.info("   Training regression model...")
     regressor = RandomForestRegressor(
@@ -221,128 +262,158 @@ def train_llm_enhanced_models(df: pd.DataFrame, epochs: int = 3, batch_size: int
         random_state=42,
         n_jobs=-1,
         bootstrap=True,
-        oob_score=True  # Out-of-bag scoring
+        oob_score=True,  # Out-of-bag scoring
     )
     regressor.fit(X_train_scaled, y_reg_train)
-    
+
     # Evaluate regression
     reg_pred = regressor.predict(X_test_scaled)
     reg_mse = mean_squared_error(y_reg_test, reg_pred)
     logger.info(f"   Regression MSE: {reg_mse:.6f}")
-    
+
     if debug:
         logger.debug("\n🔍 Feature Importance Analysis:")
         logger.debug("   Top 10 Most Important Features:")
-        
+
         feature_importance = list(zip(feature_columns, classifier.feature_importances_))
         feature_importance.sort(key=lambda x: x[1], reverse=True)
-        
+
         for i, (feature, importance) in enumerate(feature_importance[:10]):
-            emoji = "🧠" if feature.startswith('llm_') else "📊"
+            emoji = "🧠" if feature.startswith("llm_") else "📊"
             logger.debug(f"    {i+1:2d}. {emoji} {feature}: {importance:.4f}")
-    
+
     # Save models
-    import joblib
     from datetime import datetime
-    
+
+    import joblib
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    
+
     model_files = {
-        'classifier': f'models/postgres_llm_classifier_{timestamp}.joblib',
-        'regressor': f'models/postgres_llm_regressor_{timestamp}.joblib',
-        'scaler': f'models/postgres_llm_scaler_{timestamp}.joblib'
+        "classifier": f"models/postgres_llm_classifier_{timestamp}.joblib",
+        "regressor": f"models/postgres_llm_regressor_{timestamp}.joblib",
+        "scaler": f"models/postgres_llm_scaler_{timestamp}.joblib",
     }
-    
-    os.makedirs('models', exist_ok=True)
-    
-    joblib.dump(classifier, model_files['classifier'])
-    joblib.dump(regressor, model_files['regressor'])
-    joblib.dump(scaler, model_files['scaler'])
-    
+
+    os.makedirs("models", exist_ok=True)
+
+    joblib.dump(classifier, model_files["classifier"])
+    joblib.dump(regressor, model_files["regressor"])
+    joblib.dump(scaler, model_files["scaler"])
+
     logger.info(f"💾 Models saved:")
     for model_type, filepath in model_files.items():
         logger.info(f"     {model_type}: {filepath}")
-    
+
     # Save metadata
     metadata = {
-        'timestamp': datetime.now().isoformat(),
-        'data_source': 'postgresql_paper_trades',
-        'training_config': {
-            'method': 'auto',
-            'total_trades_requested': 'infinite' if (args and args.trades == 0) else (args.trades if args else 'unknown'),
-            'total_trades_loaded': len(enhanced_df),
-            'training_samples': len(X_train),
-            'test_samples': len(X_test),
-            'epochs': epochs,
-            'batch_size': batch_size,
-            'n_estimators': n_estimators,
-            'vault_enabled': args and hasattr(args, 'vault') and args.vault
+        "timestamp": datetime.now().isoformat(),
+        "data_source": "postgresql_paper_trades",
+        "training_config": {
+            "method": "auto",
+            "total_trades_requested": (
+                "infinite"
+                if (args and args.trades == 0)
+                else (args.trades if args else "unknown")
+            ),
+            "total_trades_loaded": len(enhanced_df),
+            "training_samples": len(X_train),
+            "test_samples": len(X_test),
+            "epochs": epochs,
+            "batch_size": batch_size,
+            "n_estimators": n_estimators,
+            "vault_enabled": args and hasattr(args, "vault") and args.vault,
         },
-        'data_info': {
-            'total_samples': len(enhanced_df),
-            'total_features': len(feature_columns),
-            'llm_features': len([c for c in feature_columns if c.startswith('llm_')])
+        "data_info": {
+            "total_samples": len(enhanced_df),
+            "total_features": len(feature_columns),
+            "llm_features": len([c for c in feature_columns if c.startswith("llm_")]),
         },
-        'model_performance': {
-            'classification_accuracy': float(class_accuracy),
-            'regression_mse': float(reg_mse)
+        "model_performance": {
+            "classification_accuracy": float(class_accuracy),
+            "regression_mse": float(reg_mse),
         },
-        'model_files': model_files,
-        'llm_config': {
-            'provider': llm_config.provider,
-            'model': llm_config.model,
-            'base_url': llm_config.base_url
-        }
+        "model_files": model_files,
+        "llm_config": {
+            "provider": llm_config.provider,
+            "model": llm_config.model,
+            "base_url": llm_config.base_url,
+        },
     }
-    
-    metadata_file = f'models/postgres_training_metadata_{timestamp}.json'
+
+    metadata_file = f"models/postgres_training_metadata_{timestamp}.json"
     import json
-    with open(metadata_file, 'w') as f:
+
+    with open(metadata_file, "w") as f:
         json.dump(metadata, f, indent=2)
-    
+
     logger.info(f"   Metadata saved: {metadata_file}")
-    
+
     return classifier, regressor, scaler, metadata
+
 
 def main():
     """Main training function"""
-    
-    parser = argparse.ArgumentParser(description='Train LLM-enhanced models on PostgreSQL paper trading data')
-    parser.add_argument('--method', type=str, default='auto', help='Training method (auto, manual)')
-    parser.add_argument('--trades', type=int, default=0, help='Max number of trades (0 = infinite/all available)')
+
+    parser = argparse.ArgumentParser(
+        description="Train LLM-enhanced models on PostgreSQL paper trading data"
+    )
+    parser.add_argument(
+        "--method", type=str, default="auto", help="Training method (auto, manual)"
+    )
+    parser.add_argument(
+        "--trades",
+        type=int,
+        default=0,
+        help="Max number of trades (0 = infinite/all available)",
+    )
     # Support for legacy parameter names
-    parser.add_argument('--limit', type=int, default=0, help='Legacy alias for --trades')
-    parser.add_argument('--epochs', type=int, default=20, help='Number of training epochs')
-    parser.add_argument('--horizon', type=int, default=5, help='Prediction horizon in periods')
-    parser.add_argument('--batch-size', type=int, default=10, help='LLM processing batch size')
-    parser.add_argument('--include-test', action='store_true', help='Include TEST trades in training')
-    parser.add_argument('--debug', action='store_true', help='Enable debug logging')
-    parser.add_argument('--vault', action='store_true', help='Enable Vault for secrets management')
-    
+    parser.add_argument(
+        "--limit", type=int, default=0, help="Legacy alias for --trades"
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=20, help="Number of training epochs"
+    )
+    parser.add_argument(
+        "--horizon", type=int, default=5, help="Prediction horizon in periods"
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=10, help="LLM processing batch size"
+    )
+    parser.add_argument(
+        "--include-test", action="store_true", help="Include TEST trades in training"
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument(
+        "--vault", action="store_true", help="Enable Vault for secrets management"
+    )
+
     args = parser.parse_args()
-    
+
     # Handle legacy parameter mapping
     if args.limit > 0 and args.trades == 0:
         args.trades = args.limit
-    
+
     # Setup environment based on vault setting
     if args.vault:
         # Enable Vault for secrets management
-        os.environ.pop('VAULT_ENABLED', None)
-        os.environ.pop('USE_VAULT', None)
-        os.environ.pop('VAULT_AVAILABLE', None)
-        logger_level = 'DEBUG' if args.debug else 'INFO'
-        logger = setup_logger('postgres_llm_training', logger_level)
+        os.environ.pop("VAULT_ENABLED", None)
+        os.environ.pop("USE_VAULT", None)
+        os.environ.pop("VAULT_AVAILABLE", None)
+        logger_level = "DEBUG" if args.debug else "INFO"
+        logger = setup_logger("postgres_llm_training", logger_level)
         logger.info("🔐 Vault enabled for secrets management")
     else:
         setup_llm_environment()
         # Setup logging
-        logger = setup_logger('postgres_llm_training', 'DEBUG' if args.debug else 'INFO')
+        logger = setup_logger(
+            "postgres_llm_training", "DEBUG" if args.debug else "INFO"
+        )
         logger.info("🔓 Using environment variables for secrets")
-    
+
     # Determine trades limit
     trades_text = "infinite (all available)" if args.trades == 0 else str(args.trades)
-    
+
     logger.info("🚀 Starting PostgreSQL LLM-Enhanced Training Pipeline")
     logger.info("=" * 60)
     logger.info(f"📊 Training Configuration:")
@@ -354,40 +425,52 @@ def main():
     logger.info(f"   Include TEST trades: {args.include_test}")
     logger.info(f"   Debug: {args.debug}")
     logger.info(f"   Vault: {args.vault}")
-    
+
     try:
         # Step 1: Load PostgreSQL data
         logger.info("\n📂 Step 1: Loading PostgreSQL paper trading data...")
-        df = load_postgres_training_data(include_test_trades=args.include_test, max_trades=args.trades)
-        
+        df = load_postgres_training_data(
+            include_test_trades=args.include_test, max_trades=args.trades
+        )
+
         if df.empty:
             logger.error("❌ No data loaded from PostgreSQL!")
             return 1
-        
+
         # Step 2: Create training targets
-        logger.info(f"\n🎯 Step 2: Creating training targets (horizon: {args.horizon})...")
+        logger.info(
+            f"\n🎯 Step 2: Creating training targets (horizon: {args.horizon})..."
+        )
         df_with_targets = create_training_targets(df, horizon=args.horizon)
-        
+
         # Step 3: Train LLM-enhanced models
         logger.info(f"\n🧠 Step 3: Training LLM-enhanced models...")
         classifier, regressor, scaler, metadata = train_llm_enhanced_models(
-            df_with_targets, 
+            df_with_targets,
             epochs=args.epochs,
             batch_size=args.batch_size,
             debug=args.debug,
-            args=args
+            args=args,
         )
-        
+
         # Success
         logger.info(f"\n🎉 Training Complete!")
         logger.info("=" * 60)
-        logger.info(f"✅ Classification Accuracy: {metadata['model_performance']['classification_accuracy']:.4f}")
-        logger.info(f"✅ Regression MSE: {metadata['model_performance']['regression_mse']:.6f}")
-        logger.info(f"✅ Total Features Used: {metadata['data_info']['total_features']}")
+        logger.info(
+            f"✅ Classification Accuracy: {metadata['model_performance']['classification_accuracy']:.4f}"
+        )
+        logger.info(
+            f"✅ Regression MSE: {metadata['model_performance']['regression_mse']:.6f}"
+        )
+        logger.info(
+            f"✅ Total Features Used: {metadata['data_info']['total_features']}"
+        )
         logger.info(f"🧠 LLM Features Used: {metadata['data_info']['llm_features']}")
         logger.info(f"📁 Results saved in: models/")
-        logger.info(f"📊 Training metadata: {[f for f in metadata['model_files'].values() if 'metadata' in f]}")
-        
+        logger.info(
+            f"📊 Training metadata: {[f for f in metadata['model_files'].values() if 'metadata' in f]}"
+        )
+
         print(f"\n🧠 PostgreSQL LLM-Enhanced ELVIS Training")
         print("=" * 50)
         print(f"📊 Training Configuration:")
@@ -398,27 +481,36 @@ def main():
         print(f"   Debug: {args.debug}")
         print(f"   Vault: {metadata['training_config']['vault_enabled']}")
         print(f"\n📊 Training Results:")
-        print(f"   PostgreSQL Trades Loaded: {metadata['training_config']['total_trades_loaded']}")
+        print(
+            f"   PostgreSQL Trades Loaded: {metadata['training_config']['total_trades_loaded']}"
+        )
         print(f"   Training Samples: {metadata['training_config']['training_samples']}")
         print(f"   Test Samples: {metadata['training_config']['test_samples']}")
-        print(f"   Model Trees (n_estimators): {metadata['training_config']['n_estimators']}")
+        print(
+            f"   Model Trees (n_estimators): {metadata['training_config']['n_estimators']}"
+        )
         print(f"   LLM Features: {metadata['data_info']['llm_features']}")
         print(f"   Total Features: {metadata['data_info']['total_features']}")
         print(f"\n🎯 Performance:")
-        print(f"   Classification Accuracy: {metadata['model_performance']['classification_accuracy']:.4f}")
-        print(f"   Regression MSE: {metadata['model_performance']['regression_mse']:.2e}")
+        print(
+            f"   Classification Accuracy: {metadata['model_performance']['classification_accuracy']:.4f}"
+        )
+        print(
+            f"   Regression MSE: {metadata['model_performance']['regression_mse']:.2e}"
+        )
         print(f"\n🤖 LLM Configuration:")
         print(f"   Model: {metadata['llm_config']['model']}")
         print(f"   URL: {metadata['llm_config']['base_url']}")
         print(f"\n🎉 Training completed successfully!")
         print(f"🧠 Your local LLM has been integrated with PostgreSQL paper trades!")
         print(f"📁 Check the models/ directory for results")
-        
+
         return 0
-        
+
     except Exception as e:
         logger.error(f"❌ Training failed: {e}")
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
PR #27 merged 5 training scripts that were never black/isort-formatted, so `black --check .` and `isort --check-only .` now fail on `main` (they surfaced as the Lint Code failure reported on #27 before it merged).

This is a **formatting-only** change to those 5 files — import ordering, quote normalization, and line-wrapping. No logic changes. `flake8 --select=E9,F63,F7,F82` was already clean.

Verified locally with the exact CI toolchain versions (black 26.5.1, isort 8.0.1): all three lint gates pass on tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)