### PR TITLE
fix(ci): pin current model in claude workflows (retired default 404s)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin an explicit model: the action's built-in default (claude-sonnet-4-20250514)
+          # is retired and now 404s. Use a current model ID.
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin an explicit model: the action's built-in default (claude-sonnet-4-20250514)
+          # is retired and now 404s. Use a current model ID.
+          model: "claude-sonnet-5"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Problem
The `claude-review` check has been failing on recent PRs (e.g. #27, #28). The logs show auth succeeds (OIDC → app token OK), then the run dies with:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

Both `claude-code-action` workflows (`claude-code-review.yml`, `claude.yml`) left the `model:` input **commented out**, so the action used its built-in default model `claude-sonnet-4-20250514` — which is now **retired** and returns 404.

## Fix
Pin an explicit current model (`claude-sonnet-5`) in both workflows. Uncommenting one line each; no other behavior change.

This unblocks `claude-review` on future PRs and the `@claude` mention responder (`claude.yml`), which had the same latent bug.

Note: the `CLAUDE_CODE_OAUTH_TOKEN` secret itself is fine — the failure was purely the dead model ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)