### PR TITLE
docs: fix bot_architecture_mermaid.md rendering (missing mermaid fence)

### DIFF
--- a/docs/bot_architecture_mermaid.md
+++ b/docs/bot_architecture_mermaid.md
@@ -1,3 +1,4 @@
+```mermaid
 graph TD
     Main["main.py"]
     BinanceExecutor["BinanceExecutor"]


### PR DESCRIPTION
`docs/bot_architecture_mermaid.md` rendered blank on GitHub — no diagrams shown.

## Cause
The first diagram began with a bare `graph TD` and had a closing ` ``` ` but **no opening ` ```mermaid ` fence**. The file's fences were mismatched (5, odd), so GitHub's markdown parser treated the diagram source as plain text and broke rendering for the whole file.

## Fix
Add the missing opening ` ```mermaid ` fence before `graph TD`. Fences are now balanced (6), and both the `graph TD` architecture diagram and the `classDiagram` render. Diagram content was already valid (labels quoted); this is a one-line structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)