### PR TITLE
chore: remove dead .cursor/rules (unused Cursor IDE config)

### DIFF
--- a/.cursor/rules/elvis.mdc
+++ b/.cursor/rules/elvis.mdc
@@ -1,9 +1,0 @@
----
-description: 
-globs: 
-alwaysApply: true
----
-
-# Your rule content
-
-For historical purposes, always check the CHANGELOG.md beforehand, and it must be updated with each iteration. When it’s successful, immediately document it in the CHANGELOG.md with an "eureka" tag beforehand. Also, there will be times when you decide to ask for help with the "need help" tag; then you’ll write questions for the user, who will seek assistance from other expert AIs. And so on. These steps are MANDATORY; you must take the time to document to avoid unnecessary troubleshooting loops.


### PR DESCRIPTION
`.cursor/rules/elvis.mdc` is a **Cursor IDE** rules file (`.mdc` with `alwaysApply` frontmatter). This repo is worked via Claude Code, not Cursor, so the rule is dead config.

## Why safe
- Not referenced by any code — the `cursor` grep hits are all database cursors (`conn.cursor()`) or ignore-file entries, none point at this config.
- `.cursor/` is **already gitignored** (`.gitignore:38`, `.dockerignore:31`); the file predates that rule and was committed anyway. Untracking it removes the whole `.cursor/` tree from the repo, and the existing ignore entries keep Cursor config out going forward.

Removes one file (the only thing under `.cursor/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)