### PR TITLE
fix(training): guard optional xgboost/lightgbm imports

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -16,8 +16,10 @@ imported on demand.
 > wheels** and are absent in CI / minimal environments — `optuna`, `shap`,
 > `lime`, `plotly`, `tensorflow`/`keras`. Every import of these is wrapped in a
 > `try/except ImportError` guard, and the code degrades gracefully when they are
-> missing. Do not assume they are installed. `xgboost` and `lightgbm` are used
-> by the ensembles and are expected to be present.
+> missing. Do not assume they are installed. `xgboost` and `lightgbm` are
+> likewise import-guarded: when present they are added as ensemble base models,
+> and when absent the ensembles simply drop those members. Install the full set
+> with the `ml` extra (`pip install -e '.[ml]'`).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ ml = [
   "gymnasium",
   "openai",
   "TA-Lib",
+  "xgboost",
+  "lightgbm",
 ]
 test = [
   "pytest",

--- a/tests/test_ensemble_optional_deps.py
+++ b/tests/test_ensemble_optional_deps.py
@@ -1,0 +1,46 @@
+"""Optional-dependency guarding for the ensemble base models.
+
+xgboost and lightgbm used to be unguarded top-level imports, so importing
+``training.models.ensemble_models`` (and therefore the whole
+``training.train_models`` pipeline) crashed in any environment without them.
+These tests lock in the graceful-degradation behavior.
+"""
+
+import pytest
+
+pytest.importorskip("torch", reason="ensemble_models imports torch")
+
+import training.models.ensemble_models as em
+
+
+def test_module_imports_and_exposes_guarded_boosters():
+    # Guarded imports mean lgb/xgb are either the module or None — but the
+    # module always imports, which is what unblocks the training pipeline.
+    assert hasattr(em, "lgb")
+    assert hasattr(em, "xgb")
+
+
+def test_base_regressors_degrades_when_boosters_absent(monkeypatch):
+    monkeypatch.setattr(em, "xgb", None)
+    monkeypatch.setattr(em, "lgb", None)
+    models = em._base_regressors({})
+    # Only the two always-present sklearn regressors remain.
+    assert len(models) == 2
+    assert {type(m).__name__ for m in models} == {
+        "RandomForestRegressor",
+        "GradientBoostingRegressor",
+    }
+
+
+def test_base_regressors_includes_boosters_when_present():
+    pytest.importorskip("xgboost")
+    pytest.importorskip("lightgbm")
+    names = {type(m).__name__ for m in em._base_regressors({})}
+    assert "XGBRegressor" in names
+    assert "LGBMRegressor" in names
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/training/models/ensemble_models.py
+++ b/training/models/ensemble_models.py
@@ -6,14 +6,47 @@ Implements various ensemble methods including stacking, bagging, and boosting.
 import logging
 from typing import Dict, List, Optional, Tuple, Union
 
-import lightgbm as lgb
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
-import xgboost as xgb
 from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
 from sklearn.linear_model import LinearRegression
+
+# xgboost and lightgbm are optional gradient boosters. Guard the imports so this
+# module (and the whole training pipeline that imports it) stays importable
+# without them; the ensembles just drop those base members when absent.
+try:
+    import lightgbm as lgb
+except ImportError:  # pragma: no cover - exercised in deps-absent envs
+    lgb = None
+try:
+    import xgboost as xgb
+except ImportError:  # pragma: no cover - exercised in deps-absent envs
+    xgb = None
+
+
+def _base_regressors(config: Dict) -> list:
+    """Sklearn base regressors, plus xgboost/lightgbm when installed.
+
+    The optional boosters are skipped (with a warning) when their package is
+    missing, so the ensemble degrades to the always-present sklearn models
+    instead of failing to construct.
+    """
+    models = [
+        RandomForestRegressor(**config.get("rf_params", {})),
+        GradientBoostingRegressor(**config.get("gb_params", {})),
+    ]
+    log = logging.getLogger(__name__)
+    if xgb is not None:
+        models.append(xgb.XGBRegressor(**config.get("xgb_params", {})))
+    else:
+        log.warning("xgboost not installed; skipping it as an ensemble base model")
+    if lgb is not None:
+        models.append(lgb.LGBMRegressor(**config.get("lgb_params", {})))
+    else:
+        log.warning("lightgbm not installed; skipping it as an ensemble base model")
+    return models
 
 
 class EnsembleModel:
@@ -44,15 +77,7 @@ class StackingEnsemble(EnsembleModel):
 
     def _initialize_models(self):
         """Initialize base models and meta-learner."""
-        # Base models
-        self.models = [
-            RandomForestRegressor(**self.config.get("rf_params", {})),
-            GradientBoostingRegressor(**self.config.get("gb_params", {})),
-            xgb.XGBRegressor(**self.config.get("xgb_params", {})),
-            lgb.LGBMRegressor(**self.config.get("lgb_params", {})),
-        ]
-
-        # Meta-learner
+        self.models = _base_regressors(self.config)
         self.meta_learner = LinearRegression()
 
     def fit(self, X: np.ndarray, y: np.ndarray):
@@ -83,12 +108,7 @@ class WeightedEnsemble(EnsembleModel):
 
     def _initialize_models(self):
         """Initialize base models."""
-        self.models = [
-            RandomForestRegressor(**self.config.get("rf_params", {})),
-            GradientBoostingRegressor(**self.config.get("gb_params", {})),
-            xgb.XGBRegressor(**self.config.get("xgb_params", {})),
-            lgb.LGBMRegressor(**self.config.get("lgb_params", {})),
-        ]
+        self.models = _base_regressors(self.config)
 
     def fit(self, X: np.ndarray, y: np.ndarray):
         """Fit the weighted ensemble."""


### PR DESCRIPTION
## Problem
`training/models/ensemble_models.py` imported `xgboost` and `lightgbm` unguarded at module top, and **neither is a declared dependency**. So importing `training.models.ensemble_models` — and therefore the entire `training.train_models` pipeline — raised `ModuleNotFoundError` in any environment without them (surfaced while adding a resume test in #34: the import died first on `lightgbm`, then `xgboost`).

## Fix
- Wrap both imports in `try/except ImportError -> None`, matching the `optuna`/`tensorflow` guard pattern already used in `model_trainer.py`.
- New `_base_regressors()` helper builds the base-model list, appending the boosters only when installed (warning otherwise). The ensembles degrade to the always-present sklearn regressors (RandomForest, GradientBoosting). This also de-duplicates the two identical base-model lists in `StackingEnsemble`/`WeightedEnsemble`.
- Declare `xgboost`/`lightgbm` in the pyproject `ml` extra — `pip install -e '.[ml]'` for the full stack.
- `docs/training.md`: they're import-guarded now, not "expected to be present".

## Verification
- New `tests/test_ensemble_optional_deps.py`: module imports with the boosters absent; `_base_regressors` returns exactly the two sklearn models when they're `None`; includes them when present. **3 pass.**
- Proved directly (boosters blocked via `sys.modules[...] = None`) that both `training.models.ensemble_models` **and** `training.train_models` import cleanly without lightgbm/xgboost.
- Confirmed the sibling training modules (`explainable_ai`, `rl_agents`, `transformer_models`) have no other unguarded heavy imports, so this fully unblocks the training entrypoint.

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)