### PR TITLE
feat: implement the 15-item profitability roadmap (signal gates, sizing, exits, fee gate, MTF, walk-forward)

### DIFF
--- a/docs/profitability_roadmap_implementation.md
+++ b/docs/profitability_roadmap_implementation.md
@@ -1,0 +1,107 @@
+# Profitability Roadmap — Implementation Status
+
+Implementation of the 15 ideas in [`profitability_roadmap.md`](../profitability_roadmap.md).
+Every mechanism below exists in code, is unit-tested, and (where it belongs in
+the live loop) is wired into `main.py` behind an environment flag.
+
+> **Honesty note:** the roadmap's win-rate and revenue projections
+> (35% → 75%+, $1k → $25k/month) are the roadmap author's estimates, **not
+> verified results**. What this implementation delivers is the *mechanisms*,
+> each individually tested. Measure impact in paper trading before believing
+> any number.
+
+## Status by item
+
+| # | Idea | Module / API | Wired | Flag (default) |
+|---|------|--------------|-------|----------------|
+| 1 | Market regime detector | `trading/analysis/market_regime_detector.MarketRegimeDetector` | signal loop (pre-existing) + regime cache feeds #5/#10 | always on with winrate filter |
+| 2 | RSI overbought/oversold filter | `trading.signals.filters.rsi_gate` | signal gates | `ELVIS_ROADMAP_FILTERS` (on) |
+| 3 | Volume-based trade sizing | `trading.risk.position_sizing.volume_multiplier` | sizing block | `ELVIS_VOLUME_SIZING` (on) |
+| 4 | Trailing stop loss | `trading.execution.exits.TrailingStop` | position loop | `ELVIS_TRAILING_STOP` (on), `ELVIS_TRAIL_PCT` (0.02) |
+| 5 | Fee optimization (all-in cost gate) | `trading.fees.fee_gate.is_trade_viable` | pre-execution | `ELVIS_FEE_GATE` (on) |
+| 6 | Momentum confirmation | `trading.signals.filters.has_momentum` | signal gates | `ELVIS_ROADMAP_FILTERS` (on) |
+| 7 | Bollinger Band squeeze | `trading.signals.filters.detect_bb_squeeze` | signal gates | `ELVIS_ROADMAP_FILTERS` (on) |
+| 8 | Time-of-day filter | `trading.signals.filters.is_optimal_trading_hour` | signal gates | `ELVIS_ROADMAP_FILTERS` (on) |
+| 9 | MACD histogram divergence | `trading.signals.filters.detect_macd_divergence` | signal gates (veto; override opt-in) | `ELVIS_ROADMAP_FILTERS` (on) |
+| 10 | Dynamic take profit by regime | `trading.execution.exits.dynamic_take_profit` | position loop (replaces fixed $8) | `ELVIS_DYNAMIC_TP` (on) |
+| 11 | Adaptive ML ensemble weights | `trading.signals.adaptive_ensemble.AdaptiveEnsembleWeights` | **module only** (see below) | — |
+| 12 | Order flow analysis | `trading.signals.order_flow.confirm_signal_with_flow` | signal gates | `ELVIS_ORDER_FLOW` (**off**) |
+| 13 | Kelly criterion sizing | `trading.risk.position_sizing.kelly_fraction` / `kelly_from_trades` | sizing block (caps size) | `ELVIS_KELLY_SIZING` (**off**) |
+| 14 | Multi-timeframe analysis | `trading.signals.mtf.MTFAnalyzer` | signal gates | `ELVIS_MTF` (**off**) |
+| 15 | Walk-forward optimization | `trading.optimization.walk_forward.WalkForwardOptimizer` | **offline tool** (by design) | — |
+
+## How the live wiring works
+
+All integration lives in `main.py`, mirroring the existing lazy-import pattern,
+and every stage is wrapped in try/except so a gate failure logs and never kills
+the loop.
+
+1. **Signal gates** — after the existing high-win-rate filter, a
+   `PROFITABILITY-ROADMAP SIGNAL GATES` block applies
+   `apply_signal_filters` (RSI, momentum persistence, BB squeeze,
+   trading hours, MACD divergence — each toggleable via its config key), then
+   optional order-flow confirmation and MTF alignment. Any veto downgrades the
+   signal to HOLD and logs the reason.
+2. **Regime cache** — the regime detected for each symbol is cached on
+   `main._last_regime` and reused by the dynamic-TP and fee-gate stages.
+3. **Sizing** — `volume_multiplier(data)` scales the adaptive position size
+   (0.5x–2.0x by volume vs its 20-bar mean); the optional Kelly stage derives
+   f* from the last 200 paper trades' PnL and *caps* (never raises) the size.
+4. **Fee gate** — before `execute_buy/sell`, the expected move to the
+   regime's take-profit target is compared against all-in costs (entry+exit
+   taker fees + funding); non-viable trades are skipped with a logged breakdown.
+5. **Exits** — the position loop updates a per-position `TrailingStop`
+   (2% giveback from the high-water mark, both sides) and, when the symbol's
+   regime is known, replaces the fixed $8 take-profit with the regime target
+   (TRENDING 5%, REVERSAL 1%, RANGING 0.25%, CHOPPY 0.1% — percentage-based;
+   the roadmap's absolute dollar offsets don't transfer across price levels).
+
+## Why three flags default off
+
+- **`ELVIS_ORDER_FLOW`** — paper-mode order books are empty (`get_order_book`
+  returns empty bids/asks), so the imbalance is always neutral; enable against
+  a live/testnet book.
+- **`ELVIS_KELLY_SIZING`** — Kelly needs a meaningful trade history
+  (`kelly_from_trades` returns the 1% floor below 20 trades); enable once the
+  paper DB has enough closed trades.
+- **`ELVIS_MTF`** — multiplies kline API calls per signal (3 timeframes);
+  enable deliberately.
+
+## Item 11 (adaptive ensemble) — module only, and why
+
+`AdaptiveEnsembleWeights` (EMA-updated per-model accuracies → normalized
+weights → `weighted_signal`) is implemented, tested, and persistence-capable.
+It is **not** wired into the live ensemble because the trading loop does not
+yet produce per-model accuracy feedback (which model was right per closed
+trade). Wiring it honestly requires recording each model's prediction at entry
+and scoring it at exit — that feedback pipeline is the follow-up; plugging in
+made-up accuracies would be theater.
+
+## Item 15 (walk-forward) — how to run
+
+```python
+from trading.optimization.walk_forward import (
+    WalkForwardOptimizer, sma_crossover_backtest,
+)
+import pandas as pd
+
+data = pd.read_csv("data/processed/training_data.csv")  # needs a close column
+opt = WalkForwardOptimizer(
+    backtest_fn=sma_crossover_backtest,
+    param_grid={"sma_short": [10, 14, 20], "sma_long": [40, 50, 60]},
+)
+result = opt.optimize(data, train_window=2000, test_window=500)
+print(result["best_params"], result["mean_test_metric"])
+```
+
+Run it weekly (e.g. cron) against fresh data; apply the resulting parameters
+manually or from your own automation. It is deliberately not in the live loop.
+
+## Tests
+
+`tests/test_signal_filters.py`, `test_position_sizing.py`, `test_exits.py`,
+`test_fee_gate.py`, `test_order_flow.py`, `test_mtf.py`,
+`test_adaptive_ensemble.py`, `test_walk_forward.py` — 317 tests covering the
+happy paths, edge cases (empty/short/NaN data, empty order books, degenerate
+Kelly inputs), and pinned math (Kelly formula, EMA weight updates, fee
+arithmetic). All modules import without torch/talib/network, so they run in CI.

--- a/main.py
+++ b/main.py
@@ -1821,9 +1821,16 @@ def main(mode: str, log_level: str):
                                                         get_all_trades,
                                                     )
 
+                                                    # get_all_trades rows:
+                                                    # (id, timestamp, symbol,
+                                                    #  side, price, quantity,
+                                                    #  pnl, fee) -> pnl at [6].
+                                                    # Column order is pinned by
+                                                    # tests/test_roadmap_wiring.py
+                                                    _PNL_IDX = 6
                                                     _kelly_f = kelly_from_trades(
                                                         [
-                                                            {"pnl": t[6]}
+                                                            {"pnl": t[_PNL_IDX]}
                                                             for t in get_all_trades(
                                                                 limit=200
                                                             )

--- a/main.py
+++ b/main.py
@@ -1467,6 +1467,14 @@ def main(mode: str, log_level: str):
                                                 historical_df
                                             )
 
+                                            # Cache regime per symbol for the
+                                            # dynamic-TP / fee-gate stages below
+                                            if not hasattr(main, "_last_regime"):
+                                                main._last_regime = {}
+                                            main._last_regime[symbol] = regime_result[
+                                                "regime"
+                                            ]["class"]
+
                                             # Apply filtering logic
                                             original_signal = signal
                                             original_confidence = confidence
@@ -1534,6 +1542,77 @@ def main(mode: str, log_level: str):
                                             )
                                             logger.info(
                                                 f"Continuing with original signal: {signal}"
+                                            )
+
+                                    # 🧰 PROFITABILITY-ROADMAP SIGNAL GATES
+                                    # (RSI/momentum/BB-squeeze/hours/MACD, order
+                                    # flow, MTF — each env-toggled)
+                                    if signal in ["BUY", "SELL"]:
+                                        try:
+                                            if (
+                                                os.getenv("ELVIS_ROADMAP_FILTERS", "1")
+                                                == "1"
+                                            ):
+                                                from trading.signals.filters import (
+                                                    apply_signal_filters,
+                                                )
+
+                                                signal, confidence, _gate_reasons = (
+                                                    apply_signal_filters(
+                                                        signal,
+                                                        confidence,
+                                                        data.tail(100),
+                                                        rsi=market_data.get("rsi"),
+                                                    )
+                                                )
+                                                for _reason in _gate_reasons:
+                                                    logger.warning(
+                                                        f"🚧 {symbol} filter: {_reason}"
+                                                    )
+                                            if (
+                                                signal in ["BUY", "SELL"]
+                                                and os.getenv("ELVIS_ORDER_FLOW", "0")
+                                                == "1"
+                                            ):
+                                                from trading.signals.order_flow import (
+                                                    confirm_signal_with_flow,
+                                                )
+
+                                                _flow_ok, _imbalance = (
+                                                    confirm_signal_with_flow(
+                                                        signal,
+                                                        executor.get_order_book(symbol),
+                                                    )
+                                                )
+                                                if not _flow_ok:
+                                                    logger.warning(
+                                                        f"🚧 {symbol} order flow contradicts {signal} "
+                                                        f"(imbalance {_imbalance:+.2f}) -> HOLD"
+                                                    )
+                                                    signal, confidence = "HOLD", 0.0
+                                            if (
+                                                signal in ["BUY", "SELL"]
+                                                and os.getenv("ELVIS_MTF", "0") == "1"
+                                            ):
+                                                from trading.signals.mtf import (
+                                                    MTFAnalyzer,
+                                                )
+
+                                                if not hasattr(main, "_mtf"):
+                                                    main._mtf = MTFAnalyzer(
+                                                        price_fetcher.get_historical_klines
+                                                    )
+                                                _mtf_result = main._mtf.get_signal(
+                                                    symbol
+                                                )
+                                                if _mtf_result["aligned"] != signal:
+                                                    logger.warning(
+                                                        f"🚧 {symbol} MTF misalignment {_mtf_result} -> HOLD"
+                                                    )
+                                                    signal, confidence = "HOLD", 0.0
+                                        except Exception as gate_error:
+                                            logger.error(
+                                                f"⚠️ Roadmap signal gates error: {gate_error}"
                                             )
 
                                     logger.info(
@@ -1711,6 +1790,99 @@ def main(mode: str, log_level: str):
                                             logger.info(
                                                 f"💰 ADAPTIVE SIZING: Base=${base_risk_per_trade:.0f} | Conf={confidence:.2%}({confidence_multiplier:.2f}x) | Regime=({regime_multiplier:.2f}x) | Final=${adjusted_risk:.0f}"
                                             )
+
+                                            # 📐 ROADMAP SIZING: volume-scaled +
+                                            # Kelly-capped (env-toggled)
+                                            try:
+                                                if (
+                                                    os.getenv(
+                                                        "ELVIS_VOLUME_SIZING", "1"
+                                                    )
+                                                    == "1"
+                                                ):
+                                                    from trading.risk.position_sizing import (
+                                                        volume_multiplier,
+                                                    )
+
+                                                    _vol_mult = volume_multiplier(data)
+                                                    if _vol_mult != 1.0:
+                                                        position_size *= _vol_mult
+                                                        logger.info(
+                                                            f"📐 Volume sizing {_vol_mult:.2f}x -> {position_size:.6f}"
+                                                        )
+                                                if (
+                                                    os.getenv("ELVIS_KELLY_SIZING", "0")
+                                                    == "1"
+                                                ):
+                                                    from trading.risk.position_sizing import (
+                                                        kelly_from_trades,
+                                                    )
+                                                    from utils.paper_trade_db import (
+                                                        get_all_trades,
+                                                    )
+
+                                                    _kelly_f = kelly_from_trades(
+                                                        [
+                                                            {"pnl": t[6]}
+                                                            for t in get_all_trades(
+                                                                limit=200
+                                                            )
+                                                        ]
+                                                    )
+                                                    _kelly_cap = (
+                                                        float(available_balance)
+                                                        * _kelly_f
+                                                        / float(current_price)
+                                                    )
+                                                    if 0 < _kelly_cap < position_size:
+                                                        position_size = _kelly_cap
+                                                        logger.info(
+                                                            f"📐 Kelly cap f*={_kelly_f:.3f} -> {position_size:.6f}"
+                                                        )
+                                            except Exception as sizing_error:
+                                                logger.error(
+                                                    f"⚠️ Roadmap sizing error: {sizing_error}"
+                                                )
+
+                                            # 💸 FEE GATE: skip trades whose
+                                            # regime-expected move can't beat
+                                            # all-in costs (env-toggled)
+                                            if os.getenv("ELVIS_FEE_GATE", "1") == "1":
+                                                try:
+                                                    from trading.execution.exits import (
+                                                        dynamic_take_profit,
+                                                    )
+                                                    from trading.fees.fee_gate import (
+                                                        is_trade_viable,
+                                                    )
+
+                                                    _fee_regime = getattr(
+                                                        main, "_last_regime", {}
+                                                    ).get(symbol, "RANGING")
+                                                    _tp_price = dynamic_take_profit(
+                                                        _fee_regime,
+                                                        current_price,
+                                                        side=signal,
+                                                    )
+                                                    _viable, _net, _costs = (
+                                                        is_trade_viable(
+                                                            current_price,
+                                                            _tp_price,
+                                                            position_size,
+                                                            side=signal,
+                                                        )
+                                                    )
+                                                    if not _viable:
+                                                        logger.warning(
+                                                            f"💸 {symbol} {signal} skipped by fee gate: "
+                                                            f"net ${_net:.4f} after ${_costs['total']:.4f} fees "
+                                                            f"({_fee_regime} TP target)"
+                                                        )
+                                                        signal = "HOLD"
+                                                except Exception as fee_error:
+                                                    logger.error(
+                                                        f"⚠️ Fee gate error: {fee_error}"
+                                                    )
 
                                             if signal == "BUY":
                                                 logger.info(
@@ -1895,6 +2067,60 @@ def main(mode: str, log_level: str):
                                                     f"❌ Stop loss execution error: {e}"
                                                 )
 
+                                        # 📉 TRAILING STOP (env-toggled): ratchets
+                                        # with the trend, closes on 2% giveback
+                                        if os.getenv("ELVIS_TRAILING_STOP", "1") == "1":
+                                            try:
+                                                from trading.execution.exits import (
+                                                    TrailingStop,
+                                                )
+
+                                                if not hasattr(main, "_trailing"):
+                                                    main._trailing = TrailingStop(
+                                                        trail_pct=float(
+                                                            os.getenv(
+                                                                "ELVIS_TRAIL_PCT",
+                                                                "0.02",
+                                                            )
+                                                        )
+                                                    )
+                                                _trail_close, _trail_stop = (
+                                                    main._trailing.update(
+                                                        str(position[0]),
+                                                        side.upper(),
+                                                        entry_price,
+                                                        position_current_price,
+                                                    )
+                                                )
+                                                if _trail_close:
+                                                    logger.warning(
+                                                        f"📉 TRAILING STOP hit for {pos_symbol} @ ${_trail_stop:.2f} "
+                                                        f"(price ${position_current_price:.2f})"
+                                                    )
+                                                    close_signal = (
+                                                        "SELL"
+                                                        if side.upper() == "BUY"
+                                                        else "BUY"
+                                                    )
+                                                    if executor.place_order(
+                                                        pos_symbol,
+                                                        close_signal,
+                                                        abs(quantity),
+                                                        position_current_price,
+                                                    ):
+                                                        logger.info(
+                                                            f"📉 Trailing stop executed: {close_signal} "
+                                                            f"{abs(quantity):.6f} {pos_symbol}"
+                                                        )
+                                                        main._trailing.clear(
+                                                            str(position[0])
+                                                        )
+                                                        continue  # position closed
+                                            except Exception as trail_error:
+                                                logger.error(
+                                                    f"⚠️ Trailing stop error: {trail_error}"
+                                                )
+
                                         # MICRO-SCALPING TAKE PROFIT: 10 cents profit target
                                         # Calculate absolute profit in USD
                                         if side.upper() == "BUY":  # LONG position
@@ -1908,6 +2134,42 @@ def main(mode: str, log_level: str):
 
                                         # 🎯 HIGH WIN RATE OPTIMIZED PROFIT TARGETS
                                         take_profit_threshold_usd = 8.0  # $8.00 profit target (better win rate ratio)
+
+                                        # 🎯 DYNAMIC TP (env-toggled): regime-aware
+                                        # target replaces the fixed $8 when the
+                                        # symbol's regime is known
+                                        if os.getenv("ELVIS_DYNAMIC_TP", "1") == "1":
+                                            try:
+                                                from trading.execution.exits import (
+                                                    dynamic_take_profit,
+                                                )
+
+                                                _tp_regime = getattr(
+                                                    main, "_last_regime", {}
+                                                ).get(pos_symbol)
+                                                if _tp_regime:
+                                                    _tp_target_price = (
+                                                        dynamic_take_profit(
+                                                            _tp_regime,
+                                                            entry_price,
+                                                            side=side.upper(),
+                                                        )
+                                                    )
+                                                    take_profit_threshold_usd = (
+                                                        abs(
+                                                            _tp_target_price
+                                                            - entry_price
+                                                        )
+                                                        * quantity
+                                                    )
+                                                    logger.debug(
+                                                        f"🎯 Dynamic TP {pos_symbol}: {_tp_regime} -> "
+                                                        f"${take_profit_threshold_usd:.2f}"
+                                                    )
+                                            except Exception as tp_error:
+                                                logger.error(
+                                                    f"⚠️ Dynamic TP error: {tp_error}"
+                                                )
 
                                         if absolute_profit >= take_profit_threshold_usd:
                                             logger.info(

--- a/tests/test_adaptive_ensemble.py
+++ b/tests/test_adaptive_ensemble.py
@@ -1,0 +1,193 @@
+"""Tests for trading.signals.adaptive_ensemble (roadmap item #11)."""
+
+import json
+import math
+
+import pytest
+
+from trading.signals.adaptive_ensemble import AdaptiveEnsembleWeights
+
+
+class TestWeightsNormalization:
+    def test_weights_sum_to_one_and_keep_proportions(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.6, "b": 0.4})
+        weights = ens.weights
+        assert math.isclose(sum(weights.values()), 1.0)
+        assert math.isclose(weights["a"], 0.6)
+        assert math.isclose(weights["b"], 0.4)
+
+    def test_all_zero_accuracies_give_uniform_weights(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.0, "b": 0.0, "c": 0.0})
+        weights = ens.weights
+        assert weights == {
+            "a": pytest.approx(1 / 3),
+            "b": pytest.approx(1 / 3),
+            "c": pytest.approx(1 / 3),
+        }
+
+    def test_empty_initials_give_empty_weights(self):
+        ens = AdaptiveEnsembleWeights({})
+        assert ens.weights == {}
+
+    def test_out_of_range_initial_accuracies_are_clamped(self):
+        ens = AdaptiveEnsembleWeights({"hot": 1.5, "cold": -0.2})
+        assert ens.accuracies == {"hot": 1.0, "cold": 0.0}
+
+    def test_non_finite_initial_accuracy_becomes_zero(self):
+        ens = AdaptiveEnsembleWeights({"a": float("nan"), "b": 0.5})
+        assert ens.accuracies["a"] == 0.0
+        assert math.isclose(ens.weights["b"], 1.0)
+
+
+class TestEmaUpdate:
+    def test_ema_math_pinned(self):
+        # new = 0.7 * 0.9 + 0.3 * 0.5 = 0.78
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=0.7)
+        ens.update("a", 0.9)
+        assert ens.accuracies["a"] == pytest.approx(0.78)
+
+    def test_ema_second_step(self):
+        # 0.78 -> 0.7 * 0.4 + 0.3 * 0.78 = 0.514
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=0.7)
+        ens.update("a", 0.9)
+        ens.update("a", 0.4)
+        assert ens.accuracies["a"] == pytest.approx(0.514)
+
+    def test_unknown_model_is_added_with_observed_accuracy(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        ens.update("new_model", 0.6)
+        assert ens.accuracies["new_model"] == pytest.approx(0.6)
+
+    def test_nan_accuracy_update_is_ignored(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        ens.update("a", float("nan"))
+        assert ens.accuracies["a"] == pytest.approx(0.5)
+
+    def test_non_numeric_accuracy_update_is_ignored(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        ens.update("a", "oops")
+        assert ens.accuracies["a"] == pytest.approx(0.5)
+
+    def test_out_of_range_update_is_clamped_before_ema(self):
+        # observed 2.0 clamps to 1.0 -> new = 0.7 * 1.0 + 0.3 * 0.5 = 0.85
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=0.7)
+        ens.update("a", 2.0)
+        assert ens.accuracies["a"] == pytest.approx(0.85)
+
+    def test_boundary_alpha_zero_and_one(self):
+        frozen = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=0.0)
+        frozen.update("a", 0.9)
+        assert frozen.accuracies["a"] == pytest.approx(0.5)
+
+        instant = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=1.0)
+        instant.update("a", 0.9)
+        assert instant.accuracies["a"] == pytest.approx(0.9)
+
+    def test_out_of_range_alpha_is_clamped(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, ema_alpha=1.7)
+        ens.update("a", 0.9)  # clamped alpha == 1.0
+        assert ens.accuracies["a"] == pytest.approx(0.9)
+
+
+class TestWeightedSignal:
+    def test_full_intersection_weighted_average(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.6, "b": 0.4})
+        signal = ens.weighted_signal({"a": 1.0, "b": -1.0})
+        assert signal == pytest.approx(0.6 * 1.0 + 0.4 * -1.0)
+
+    def test_subset_is_renormalized(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5, "b": 0.3, "c": 0.2})
+        # Only a and b report: weights become 0.5/0.8 and 0.3/0.8.
+        signal = ens.weighted_signal({"a": 1.0, "b": -1.0})
+        assert signal == pytest.approx((0.5 - 0.3) / 0.8)
+
+    def test_empty_intersection_returns_neutral_zero(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        assert ens.weighted_signal({"unknown": 1.0}) == 0.0
+
+    def test_empty_predictions_return_neutral_zero(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        assert ens.weighted_signal({}) == 0.0
+
+    def test_no_models_tracked_returns_neutral_zero(self):
+        ens = AdaptiveEnsembleWeights({})
+        assert ens.weighted_signal({"a": 1.0}) == 0.0
+
+    def test_nan_prediction_is_skipped(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5, "b": 0.5})
+        signal = ens.weighted_signal({"a": float("nan"), "b": 1.0})
+        assert signal == pytest.approx(1.0)
+
+    def test_all_nan_predictions_return_neutral_zero(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        assert ens.weighted_signal({"a": float("nan")}) == 0.0
+
+    def test_zero_weight_subset_falls_back_to_plain_mean(self):
+        # a dominates the weights, but only zero-accuracy models report.
+        ens = AdaptiveEnsembleWeights({"a": 0.9, "b": 0.0, "c": 0.0})
+        signal = ens.weighted_signal({"b": 1.0, "c": 0.5})
+        assert signal == pytest.approx(0.75)
+
+
+class TestPersistence:
+    def test_save_load_round_trip(self, tmp_path):
+        state = str(tmp_path / "weights.json")
+        first = AdaptiveEnsembleWeights(
+            {"a": 0.5, "b": 0.5}, ema_alpha=0.7, state_path=state
+        )
+        first.update("a", 0.9)
+        first.save()
+
+        second = AdaptiveEnsembleWeights(
+            {"a": 0.5, "b": 0.5}, ema_alpha=0.7, state_path=state
+        )
+        assert second.accuracies["a"] == pytest.approx(0.78)
+        assert second.accuracies["b"] == pytest.approx(0.5)
+
+    def test_missing_state_file_falls_back_to_initials(self, tmp_path):
+        state = str(tmp_path / "does_not_exist.json")
+        ens = AdaptiveEnsembleWeights({"a": 0.6}, state_path=state)
+        assert ens.accuracies == {"a": 0.6}
+
+    def test_corrupt_state_file_falls_back_to_initials(self, tmp_path):
+        state = tmp_path / "weights.json"
+        state.write_text("{not valid json!!", encoding="utf-8")
+        ens = AdaptiveEnsembleWeights({"a": 0.6}, state_path=str(state))
+        assert ens.accuracies == {"a": 0.6}
+        assert ens.load() is False
+
+    def test_wrong_shape_state_file_falls_back_to_initials(self, tmp_path):
+        state = tmp_path / "weights.json"
+        state.write_text(json.dumps({"accuracies": [1, 2, 3]}), encoding="utf-8")
+        ens = AdaptiveEnsembleWeights({"a": 0.6}, state_path=str(state))
+        assert ens.accuracies == {"a": 0.6}
+
+    def test_loaded_state_merges_over_initials(self, tmp_path):
+        state = tmp_path / "weights.json"
+        state.write_text(
+            json.dumps({"ema_alpha": 0.7, "accuracies": {"a": 0.9}}), encoding="utf-8"
+        )
+        # "b" is new in code and absent from the saved state: it must survive.
+        ens = AdaptiveEnsembleWeights({"a": 0.5, "b": 0.4}, state_path=str(state))
+        assert ens.accuracies == {"a": pytest.approx(0.9), "b": pytest.approx(0.4)}
+
+    def test_save_without_state_path_is_noop(self):
+        ens = AdaptiveEnsembleWeights({"a": 0.5})
+        ens.save()  # must not raise
+        assert ens.load() is False
+
+    def test_save_writes_valid_json_atomically(self, tmp_path):
+        state = tmp_path / "weights.json"
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, state_path=str(state))
+        ens.save()
+        payload = json.loads(state.read_text(encoding="utf-8"))
+        assert payload["accuracies"] == {"a": 0.5}
+        assert payload["ema_alpha"] == pytest.approx(0.7)
+        leftovers = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert leftovers == []
+
+    def test_save_creates_missing_parent_directory(self, tmp_path):
+        state = tmp_path / "nested" / "dir" / "weights.json"
+        ens = AdaptiveEnsembleWeights({"a": 0.5}, state_path=str(state))
+        ens.save()
+        assert state.exists()

--- a/tests/test_exits.py
+++ b/tests/test_exits.py
@@ -1,0 +1,242 @@
+"""
+Tests for trading.execution.exits: TrailingStop and dynamic_take_profit.
+
+Plain pytest, stdlib-only assertions -- no torch, no network.
+"""
+
+import math
+
+import pytest
+
+from trading.execution.exits import (
+    DEFAULT_REGIME_TP_PCT,
+    TrailingStop,
+    dynamic_take_profit,
+)
+
+
+class TestTrailingStopBuy:
+    """BUY (long) side: stop trails below the high-water mark."""
+
+    def test_first_update_seeds_with_max_of_entry_and_current(self):
+        ts = TrailingStop(trail_pct=0.02)
+        # current above entry -> extreme seeded at current
+        should_close, stop = ts.update("p1", "BUY", 100.0, 105.0)
+        assert should_close is False
+        assert stop == pytest.approx(105.0 * 0.98)
+
+    def test_first_update_seeds_with_entry_when_current_lower(self):
+        ts = TrailingStop(trail_pct=0.02)
+        should_close, stop = ts.update("p1", "BUY", 100.0, 99.5)
+        # extreme = max(100, 99.5) = 100 -> stop = 98
+        assert stop == pytest.approx(98.0)
+        assert should_close is False
+
+    def test_stop_rises_with_new_highs(self):
+        ts = TrailingStop(trail_pct=0.02)
+        _, stop1 = ts.update("p1", "BUY", 100.0, 100.0)
+        _, stop2 = ts.update("p1", "BUY", 100.0, 110.0)
+        _, stop3 = ts.update("p1", "BUY", 100.0, 120.0)
+        assert stop1 < stop2 < stop3
+        assert stop3 == pytest.approx(120.0 * 0.98)
+
+    def test_stop_never_falls_on_pullback(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("p1", "BUY", 100.0, 120.0)
+        # pull back but stay above the stop (120 * 0.98 = 117.6)
+        should_close, stop = ts.update("p1", "BUY", 100.0, 118.0)
+        assert should_close is False
+        assert stop == pytest.approx(120.0 * 0.98)  # unchanged high-water mark
+
+    def test_triggers_when_price_crosses_stop(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("p1", "BUY", 100.0, 120.0)
+        should_close, stop = ts.update("p1", "BUY", 100.0, 117.0)
+        assert should_close is True
+        assert stop == pytest.approx(117.6)
+
+    def test_triggers_exactly_at_stop_price(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("p1", "BUY", 100.0, 100.0)
+        should_close, stop = ts.update("p1", "BUY", 100.0, 98.0)
+        assert stop == pytest.approx(98.0)
+        assert should_close is True  # current <= stop triggers
+
+
+class TestTrailingStopSell:
+    """SELL (short) side: mirrored -- stop trails above the low-water mark."""
+
+    def test_first_update_seeds_with_min_of_entry_and_current(self):
+        ts = TrailingStop(trail_pct=0.02)
+        should_close, stop = ts.update("s1", "SELL", 100.0, 95.0)
+        assert should_close is False
+        assert stop == pytest.approx(95.0 * 1.02)
+
+    def test_first_update_seeds_with_entry_when_current_higher(self):
+        ts = TrailingStop(trail_pct=0.02)
+        _, stop = ts.update("s1", "SELL", 100.0, 100.5)
+        # extreme = min(100, 100.5) = 100 -> stop = 102
+        assert stop == pytest.approx(102.0)
+
+    def test_stop_falls_with_new_lows(self):
+        ts = TrailingStop(trail_pct=0.02)
+        _, stop1 = ts.update("s1", "SELL", 100.0, 100.0)
+        _, stop2 = ts.update("s1", "SELL", 100.0, 90.0)
+        _, stop3 = ts.update("s1", "SELL", 100.0, 80.0)
+        assert stop1 > stop2 > stop3
+        assert stop3 == pytest.approx(80.0 * 1.02)
+
+    def test_stop_never_rises_on_bounce(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("s1", "SELL", 100.0, 80.0)
+        # bounce but stay below the stop (80 * 1.02 = 81.6)
+        should_close, stop = ts.update("s1", "SELL", 100.0, 81.0)
+        assert should_close is False
+        assert stop == pytest.approx(81.6)
+
+    def test_triggers_when_price_crosses_stop(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("s1", "SELL", 100.0, 80.0)
+        should_close, stop = ts.update("s1", "SELL", 100.0, 82.0)
+        assert should_close is True
+        assert stop == pytest.approx(81.6)
+
+
+class TestTrailingStopState:
+    """Per-position state, clear(), and input hardening."""
+
+    def test_positions_are_independent(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("a", "BUY", 100.0, 120.0)
+        _, stop_b = ts.update("b", "BUY", 100.0, 100.0)
+        # position b's stop unaffected by a's high-water mark
+        assert stop_b == pytest.approx(98.0)
+
+    def test_clear_forgets_state(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("p1", "BUY", 100.0, 120.0)
+        ts.clear("p1")
+        # re-seeded from scratch: extreme = max(100, 100) = 100
+        _, stop = ts.update("p1", "BUY", 100.0, 100.0)
+        assert stop == pytest.approx(98.0)
+
+    def test_clear_unknown_id_is_noop(self):
+        ts = TrailingStop()
+        ts.clear("never-seen")  # must not raise
+
+    def test_invalid_current_price_is_neutral(self):
+        ts = TrailingStop()
+        assert ts.update("p1", "BUY", 100.0, float("nan")) == (False, 0.0)
+        assert ts.update("p1", "BUY", 100.0, -5.0) == (False, 0.0)
+        assert ts.update("p1", "BUY", 100.0, 0.0) == (False, 0.0)
+        assert ts.update("p1", "BUY", 100.0, float("inf")) == (False, 0.0)
+
+    def test_invalid_entry_price_falls_back_to_current(self):
+        ts = TrailingStop(trail_pct=0.02)
+        should_close, stop = ts.update("p1", "BUY", float("nan"), 100.0)
+        assert should_close is False
+        assert stop == pytest.approx(98.0)
+
+    def test_invalid_trail_pct_uses_default(self):
+        assert TrailingStop(trail_pct=float("nan")).trail_pct == pytest.approx(0.02)
+        assert TrailingStop(trail_pct=-0.1).trail_pct == pytest.approx(0.02)
+
+    def test_side_is_case_insensitive(self):
+        ts = TrailingStop(trail_pct=0.02)
+        _, stop = ts.update("p1", "buy", 100.0, 110.0)
+        assert stop == pytest.approx(110.0 * 0.98)
+
+    def test_unknown_side_treated_as_buy(self):
+        ts = TrailingStop(trail_pct=0.02)
+        _, stop = ts.update("p1", "HOLD", 100.0, 110.0)
+        assert stop == pytest.approx(110.0 * 0.98)
+
+    def test_side_flip_reseeds_state(self):
+        ts = TrailingStop(trail_pct=0.02)
+        ts.update("p1", "BUY", 100.0, 120.0)
+        # same id re-used as SELL: old high-water mark must not leak
+        _, stop = ts.update("p1", "SELL", 100.0, 100.0)
+        assert stop == pytest.approx(102.0)
+
+
+class TestDynamicTakeProfitBuy:
+    def test_trending(self):
+        assert dynamic_take_profit("TRENDING", 100.0, "BUY") == pytest.approx(105.0)
+
+    def test_reversal(self):
+        assert dynamic_take_profit("REVERSAL", 100.0, "BUY") == pytest.approx(101.0)
+
+    def test_ranging(self):
+        assert dynamic_take_profit("RANGING", 100.0, "BUY") == pytest.approx(100.25)
+
+    def test_choppy(self):
+        assert dynamic_take_profit("CHOPPY", 100.0, "BUY") == pytest.approx(100.1)
+
+    def test_unknown_regime_uses_ranging_fallback(self):
+        assert dynamic_take_profit("LUNAR", 100.0, "BUY") == pytest.approx(100.25)
+
+    def test_default_side_is_buy(self):
+        assert dynamic_take_profit("TRENDING", 100.0) == pytest.approx(105.0)
+
+
+class TestDynamicTakeProfitSell:
+    def test_trending(self):
+        assert dynamic_take_profit("TRENDING", 100.0, "SELL") == pytest.approx(95.0)
+
+    def test_reversal(self):
+        assert dynamic_take_profit("REVERSAL", 100.0, "SELL") == pytest.approx(99.0)
+
+    def test_ranging(self):
+        assert dynamic_take_profit("RANGING", 100.0, "SELL") == pytest.approx(99.75)
+
+    def test_choppy(self):
+        assert dynamic_take_profit("CHOPPY", 100.0, "SELL") == pytest.approx(99.9)
+
+    def test_unknown_regime_uses_ranging_fallback(self):
+        assert dynamic_take_profit("???", 100.0, "SELL") == pytest.approx(99.75)
+
+
+class TestDynamicTakeProfitEdges:
+    def test_regime_case_insensitive(self):
+        assert dynamic_take_profit("trending", 100.0, "BUY") == pytest.approx(105.0)
+
+    def test_side_case_insensitive(self):
+        assert dynamic_take_profit("TRENDING", 100.0, "sell") == pytest.approx(95.0)
+
+    def test_unknown_side_treated_as_buy(self):
+        assert dynamic_take_profit("TRENDING", 100.0, "WAT") == pytest.approx(105.0)
+
+    def test_custom_map_merges_over_defaults(self):
+        custom = {"TRENDING": 0.10}
+        assert dynamic_take_profit(
+            "TRENDING", 100.0, "BUY", regime_pct=custom
+        ) == pytest.approx(110.0)
+        # keys not overridden keep their defaults
+        assert dynamic_take_profit(
+            "CHOPPY", 100.0, "BUY", regime_pct=custom
+        ) == pytest.approx(100.1)
+
+    def test_custom_map_can_add_new_regime(self):
+        custom = {"PARABOLIC": 0.2}
+        assert dynamic_take_profit(
+            "PARABOLIC", 100.0, "BUY", regime_pct=custom
+        ) == pytest.approx(120.0)
+
+    def test_invalid_custom_value_ignored(self):
+        custom = {"TRENDING": float("nan")}
+        assert dynamic_take_profit(
+            "TRENDING", 100.0, "BUY", regime_pct=custom
+        ) == pytest.approx(105.0)
+
+    def test_custom_map_does_not_mutate_defaults(self):
+        before = dict(DEFAULT_REGIME_TP_PCT)
+        dynamic_take_profit("TRENDING", 100.0, "BUY", regime_pct={"TRENDING": 0.5})
+        assert DEFAULT_REGIME_TP_PCT == before
+
+    def test_invalid_entry_price_is_neutral(self):
+        assert math.isnan(dynamic_take_profit("TRENDING", float("nan"), "BUY"))
+        assert dynamic_take_profit("TRENDING", 0.0, "BUY") == pytest.approx(0.0)
+        assert dynamic_take_profit("TRENDING", -10.0, "BUY") == pytest.approx(-10.0)
+
+    def test_none_regime_uses_fallback(self):
+        assert dynamic_take_profit(None, 100.0, "BUY") == pytest.approx(100.25)

--- a/tests/test_fee_gate.py
+++ b/tests/test_fee_gate.py
@@ -1,0 +1,186 @@
+"""Tests for trading/fees/fee_gate.py (fee-aware trade viability gate)."""
+
+import math
+
+import pytest
+
+from trading.fees.fee_gate import (
+    DEFAULT_FUNDING_RATE,
+    DEFAULT_TAKER_FEE,
+    all_in_cost,
+    is_trade_viable,
+)
+
+ENTRY = 50_000.0
+QTY = 0.01  # notional = 500 USDT at 1x
+
+
+class TestAllInCost:
+    def test_default_breakdown_exact_math(self):
+        costs = all_in_cost(ENTRY, QTY)
+        # notional = 500; taker 0.0004 -> 0.2 each side; funding 0.0001 -> 0.05
+        assert costs["entry_fee"] == pytest.approx(0.2)
+        assert costs["exit_fee"] == pytest.approx(0.2)
+        assert costs["funding_fee"] == pytest.approx(0.05)
+        assert costs["total"] == pytest.approx(0.45)
+        assert set(costs) == {"entry_fee", "exit_fee", "funding_fee", "total"}
+
+    def test_defaults_mirror_binance_constants(self):
+        assert DEFAULT_TAKER_FEE == 0.0004  # 0.04% futures taker
+        assert DEFAULT_FUNDING_RATE == 0.0001
+
+    def test_leverage_scales_notional(self):
+        costs_1x = all_in_cost(ENTRY, QTY, leverage=1.0)
+        costs_10x = all_in_cost(ENTRY, QTY, leverage=10.0)
+        for key in ("entry_fee", "exit_fee", "funding_fee", "total"):
+            assert costs_10x[key] == pytest.approx(10.0 * costs_1x[key])
+
+    def test_funding_periods_multiply_funding_only(self):
+        costs = all_in_cost(ENTRY, QTY, funding_periods=3)
+        assert costs["funding_fee"] == pytest.approx(0.15)
+        assert costs["entry_fee"] == pytest.approx(0.2)
+        assert costs["total"] == pytest.approx(0.55)
+
+    def test_zero_funding_periods(self):
+        costs = all_in_cost(ENTRY, QTY, funding_periods=0)
+        assert costs["funding_fee"] == 0.0
+        assert costs["total"] == pytest.approx(0.4)
+
+    @pytest.mark.parametrize(
+        "entry_price,quantity,leverage",
+        [
+            (float("nan"), QTY, 1.0),
+            (ENTRY, float("nan"), 1.0),
+            (ENTRY, QTY, float("nan")),
+            (float("inf"), QTY, 1.0),
+            (0.0, QTY, 1.0),
+            (ENTRY, 0.0, 1.0),
+            (-1.0, QTY, 1.0),
+            (ENTRY, -0.5, 1.0),
+            (ENTRY, QTY, 0.0),
+            (None, QTY, 1.0),
+        ],
+    )
+    def test_invalid_inputs_return_zero_costs(self, entry_price, quantity, leverage):
+        costs = all_in_cost(entry_price, quantity, leverage=leverage)
+        assert costs == {
+            "entry_fee": 0.0,
+            "exit_fee": 0.0,
+            "funding_fee": 0.0,
+            "total": 0.0,
+        }
+
+    def test_non_finite_fee_params_return_zero_costs(self):
+        assert all_in_cost(ENTRY, QTY, taker_fee=float("nan"))["total"] == 0.0
+        assert all_in_cost(ENTRY, QTY, funding_rate=float("inf"))["total"] == 0.0
+
+
+class TestIsTradeViable:
+    def test_tight_move_eaten_by_fees(self):
+        # gross = 10 * 0.01 = 0.10 vs total fees 0.45 -> net -0.35
+        viable, net, costs = is_trade_viable(ENTRY, ENTRY + 10.0, QTY, side="BUY")
+        assert viable is False
+        assert net == pytest.approx(-0.35)
+        assert costs["total"] == pytest.approx(0.45)
+
+    def test_wide_move_viable_exact_net(self):
+        # gross = 100 * 0.01 = 1.0; net = 1.0 - 0.45 = 0.55
+        viable, net, costs = is_trade_viable(ENTRY, ENTRY + 100.0, QTY, side="BUY")
+        assert viable is True
+        assert net == pytest.approx(0.55)
+        assert costs["entry_fee"] == pytest.approx(0.2)
+
+    def test_sell_direction(self):
+        # SELL profits on a drop: gross = (50000 - 49900) * 0.01 = 1.0
+        viable, net, _ = is_trade_viable(ENTRY, ENTRY - 100.0, QTY, side="SELL")
+        assert viable is True
+        assert net == pytest.approx(0.55)
+        # A SELL into a rising price loses gross AND pays fees.
+        viable_up, net_up, _ = is_trade_viable(ENTRY, ENTRY + 100.0, QTY, side="SELL")
+        assert viable_up is False
+        assert net_up == pytest.approx(-1.45)
+
+    def test_leverage_scales_gross_and_fees(self):
+        viable, net, costs = is_trade_viable(
+            ENTRY, ENTRY + 100.0, QTY, side="BUY", leverage=10.0
+        )
+        # gross = 1.0 * 10 = 10.0; fees = 0.45 * 10 = 4.5; net = 5.5
+        assert viable is True
+        assert net == pytest.approx(5.5)
+        assert costs["total"] == pytest.approx(4.5)
+
+    def test_min_net_profit_boundary_is_strict(self):
+        # net is exactly 0.55: threshold 0.55 must reject, just below accepts.
+        viable_at, net, _ = is_trade_viable(
+            ENTRY, ENTRY + 100.0, QTY, min_net_profit=0.55
+        )
+        assert net == pytest.approx(0.55)
+        assert viable_at is False
+        viable_below, _, _ = is_trade_viable(
+            ENTRY, ENTRY + 100.0, QTY, min_net_profit=0.5
+        )
+        assert viable_below is True
+
+    def test_side_aliases_and_case_insensitive(self):
+        viable_buy, net_buy, _ = is_trade_viable(ENTRY, ENTRY + 100.0, QTY, side="buy")
+        viable_long, net_long, _ = is_trade_viable(
+            ENTRY, ENTRY + 100.0, QTY, side="LONG"
+        )
+        assert viable_buy is viable_long is True
+        assert net_buy == pytest.approx(net_long)
+        viable_short, net_short, _ = is_trade_viable(
+            ENTRY, ENTRY - 100.0, QTY, side="short"
+        )
+        assert viable_short is True
+        assert net_short == pytest.approx(0.55)
+
+    def test_unknown_side_is_neutral(self):
+        viable, net, costs = is_trade_viable(ENTRY, ENTRY + 100.0, QTY, side="HODL")
+        assert viable is False
+        assert net == 0.0
+        assert costs["total"] == 0.0
+
+    @pytest.mark.parametrize(
+        "entry_price,exit_price,quantity",
+        [
+            (float("nan"), ENTRY + 100.0, QTY),
+            (ENTRY, float("nan"), QTY),
+            (ENTRY, ENTRY + 100.0, float("nan")),
+            (ENTRY, ENTRY + 100.0, 0.0),
+            (ENTRY, ENTRY + 100.0, -1.0),
+            (ENTRY, 0.0, QTY),
+            (ENTRY, float("inf"), QTY),
+        ],
+    )
+    def test_invalid_inputs_neutral_no_raise(self, entry_price, exit_price, quantity):
+        viable, net, costs = is_trade_viable(entry_price, exit_price, quantity)
+        assert viable is False
+        assert net == 0.0
+        assert costs["total"] == 0.0
+
+    def test_nan_min_net_profit_neutral(self):
+        viable, net, _ = is_trade_viable(
+            ENTRY, ENTRY + 100.0, QTY, min_net_profit=float("nan")
+        )
+        assert viable is False
+        assert net == 0.0
+
+    def test_fee_kw_passthrough(self):
+        # Zero out all fees: net == gross and any positive move is viable.
+        viable, net, costs = is_trade_viable(
+            ENTRY,
+            ENTRY + 10.0,
+            QTY,
+            taker_fee=0.0,
+            funding_rate=0.0,
+        )
+        assert viable is True
+        assert net == pytest.approx(0.10)
+        assert costs["total"] == 0.0
+
+    def test_breakeven_move_not_viable(self):
+        # No price move: gross 0, net = -fees.
+        viable, net, _ = is_trade_viable(ENTRY, ENTRY, QTY)
+        assert viable is False
+        assert net == pytest.approx(-0.45)
+        assert math.isfinite(net)

--- a/tests/test_mtf.py
+++ b/tests/test_mtf.py
@@ -1,0 +1,220 @@
+"""Tests for trading.signals.mtf (multi-timeframe alignment, roadmap #14)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading.signals.mtf import BUY, HOLD, SELL, MTFAnalyzer, sma_trend_signal
+
+
+def make_df(closes) -> pd.DataFrame:
+    """Build a minimal kline-like DataFrame with a close column."""
+    return pd.DataFrame({"close": list(closes)})
+
+
+def rising_df(n: int = 60) -> pd.DataFrame:
+    return make_df(np.linspace(100.0, 130.0, n))
+
+
+def falling_df(n: int = 60) -> pd.DataFrame:
+    return make_df(np.linspace(130.0, 100.0, n))
+
+
+def flat_df(n: int = 60) -> pd.DataFrame:
+    return make_df([100.0] * n)
+
+
+class TestSmaTrendSignal:
+    def test_uptrend_returns_buy(self):
+        assert sma_trend_signal(rising_df()) == BUY
+
+    def test_downtrend_returns_sell(self):
+        assert sma_trend_signal(falling_df()) == SELL
+
+    def test_flat_returns_hold(self):
+        assert sma_trend_signal(flat_df()) == HOLD
+
+    def test_short_data_returns_hold(self):
+        assert sma_trend_signal(rising_df(49)) == HOLD
+
+    def test_exactly_slow_rows_is_enough(self):
+        assert sma_trend_signal(rising_df(50)) == BUY
+
+    def test_empty_dataframe_returns_hold(self):
+        assert sma_trend_signal(pd.DataFrame()) == HOLD
+
+    def test_none_returns_hold(self):
+        assert sma_trend_signal(None) == HOLD
+
+    def test_missing_close_column_returns_hold(self):
+        df = pd.DataFrame({"open": np.linspace(100, 130, 60)})
+        assert sma_trend_signal(df) == HOLD
+
+    def test_spread_below_threshold_returns_hold(self):
+        # 30 closes at 100 then 20 at 100.05:
+        # SMA(20)=100.05, SMA(50)=100.02 -> spread ~0.03% < 0.1%
+        assert sma_trend_signal(make_df([100.0] * 30 + [100.05] * 20)) == HOLD
+
+    def test_spread_above_threshold_returns_buy(self):
+        # SMA(20)=100.3, SMA(50)=100.12 -> spread ~0.18% > 0.1%
+        assert sma_trend_signal(make_df([100.0] * 30 + [100.3] * 20)) == BUY
+
+    def test_spread_below_negative_threshold_returns_sell(self):
+        # SMA(20)=99.7, SMA(50)=99.88 -> spread ~-0.18% < -0.1%
+        assert sma_trend_signal(make_df([100.0] * 30 + [99.7] * 20)) == SELL
+
+    def test_nan_closes_are_dropped(self):
+        closes = list(np.linspace(100.0, 130.0, 60))
+        closes[3] = np.nan
+        closes[10] = np.nan
+        assert sma_trend_signal(make_df(closes)) == BUY
+
+    def test_nans_reducing_below_slow_returns_hold(self):
+        closes = list(np.linspace(100.0, 130.0, 52))
+        for i in range(5):
+            closes[i] = np.nan  # 47 valid closes < slow=50
+        assert sma_trend_signal(make_df(closes)) == HOLD
+
+    def test_non_numeric_closes_returns_hold(self):
+        assert sma_trend_signal(make_df(["oops"] * 60)) == HOLD
+
+    def test_string_numbers_are_coerced(self):
+        closes = [f"{v:.4f}" for v in np.linspace(100.0, 130.0, 60)]
+        assert sma_trend_signal(make_df(closes)) == BUY
+
+    def test_invalid_windows_return_hold(self):
+        assert sma_trend_signal(rising_df(), fast=0) == HOLD
+        assert sma_trend_signal(rising_df(), fast=50, slow=20) == HOLD
+        assert sma_trend_signal(rising_df(), slow=-1) == HOLD
+
+    def test_custom_windows(self):
+        assert sma_trend_signal(rising_df(12), fast=3, slow=10) == BUY
+
+
+def make_klines(closes):
+    """Build Binance-style raw kline lists (index 4 = close, as strings)."""
+    return [
+        [
+            1700000000000 + i,
+            "1",
+            "2",
+            "0.5",
+            f"{c:.8f}",
+            "10.0",
+            0,
+            "0",
+            0,
+            "0",
+            "0",
+            "0",
+        ]
+        for i, c in enumerate(closes)
+    ]
+
+
+class RecordingFetcher:
+    """Fake fetch_klines returning canned data per interval."""
+
+    def __init__(self, data_by_interval, default=None):
+        self.data_by_interval = data_by_interval
+        self.default = default
+        self.calls = []
+
+    def __call__(self, symbol, interval, limit):
+        self.calls.append((symbol, interval, limit))
+        return self.data_by_interval.get(interval, self.default)
+
+
+class TestMTFAnalyzer:
+    def test_full_buy_alignment(self):
+        fetcher = RecordingFetcher({}, default=rising_df())
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["aligned"] == BUY
+        assert result["signals"] == {"15m": BUY, "1h": BUY, "4h": BUY}
+        assert result["symbol"] == "BTCUSDT"
+
+    def test_full_sell_alignment(self):
+        fetcher = RecordingFetcher({}, default=falling_df())
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["aligned"] == SELL
+        assert set(result["signals"].values()) == {SELL}
+
+    def test_partial_alignment_returns_hold(self):
+        fetcher = RecordingFetcher(
+            {"15m": rising_df(), "1h": rising_df(), "4h": flat_df()}
+        )
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["signals"] == {"15m": BUY, "1h": BUY, "4h": HOLD}
+        assert result["aligned"] == HOLD
+
+    def test_mixed_buy_sell_returns_hold(self):
+        fetcher = RecordingFetcher(
+            {"15m": rising_df(), "1h": falling_df(), "4h": rising_df()}
+        )
+        assert MTFAnalyzer(fetcher).get_signal("BTCUSDT")["aligned"] == HOLD
+
+    def test_fetch_exception_maps_to_hold_and_never_raises(self):
+        def fetcher(symbol, interval, limit):
+            if interval == "1h":
+                raise ConnectionError("exchange down")
+            return rising_df()
+
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["signals"]["1h"] == HOLD
+        assert result["signals"]["15m"] == BUY
+        assert result["aligned"] == HOLD
+
+    def test_fetch_none_maps_to_hold(self):
+        fetcher = RecordingFetcher(
+            {"15m": rising_df(), "1h": rising_df()}
+        )  # 4h -> None
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["signals"]["4h"] == HOLD
+        assert result["aligned"] == HOLD
+
+    def test_fetch_empty_dataframe_maps_to_hold(self):
+        fetcher = RecordingFetcher({}, default=pd.DataFrame())
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["aligned"] == HOLD
+        assert set(result["signals"].values()) == {HOLD}
+
+    def test_list_shaped_klines_are_coerced(self):
+        fetcher = RecordingFetcher({}, default=make_klines(np.linspace(100, 130, 60)))
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["aligned"] == BUY
+
+    def test_short_list_klines_map_to_hold(self):
+        fetcher = RecordingFetcher({}, default=make_klines([100.0] * 10))
+        assert MTFAnalyzer(fetcher).get_signal("BTCUSDT")["aligned"] == HOLD
+
+    def test_malformed_rows_map_to_hold(self):
+        fetcher = RecordingFetcher({}, default=[[1, 2], "junk", None])
+        result = MTFAnalyzer(fetcher).get_signal("BTCUSDT")
+        assert result["aligned"] == HOLD
+
+    def test_fetcher_called_once_per_timeframe_with_args(self):
+        fetcher = RecordingFetcher({}, default=rising_df())
+        MTFAnalyzer(fetcher, timeframes=("5m", "1d"), limit=75).get_signal("ETHUSDT")
+        assert fetcher.calls == [("ETHUSDT", "5m", 75), ("ETHUSDT", "1d", 75)]
+
+    def test_custom_timeframes_in_result(self):
+        fetcher = RecordingFetcher({}, default=rising_df())
+        result = MTFAnalyzer(fetcher, timeframes=("1m",)).get_signal("BTCUSDT")
+        assert list(result["signals"]) == ["1m"]
+        assert result["aligned"] == BUY
+
+    def test_empty_timeframes_returns_hold_not_buy(self):
+        # all() over an empty dict is vacuously True; must not report BUY.
+        fetcher = RecordingFetcher({}, default=rising_df())
+        result = MTFAnalyzer(fetcher, timeframes=()).get_signal("BTCUSDT")
+        assert result["signals"] == {}
+        assert result["aligned"] == HOLD
+
+    def test_limit_below_slow_yields_hold(self):
+        fetcher = RecordingFetcher({}, default=rising_df(30))
+        result = MTFAnalyzer(fetcher, limit=30).get_signal("BTCUSDT")
+        assert result["aligned"] == HOLD
+
+    def test_non_callable_fetcher_raises_typeerror(self):
+        with pytest.raises(TypeError):
+            MTFAnalyzer(fetch_klines="not-callable")

--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -1,0 +1,207 @@
+"""Tests for trading.signals.order_flow (roadmap item #12).
+
+Covers order-book imbalance computation (balanced/one-sided/empty books,
+string quantities, depth truncation, malformed levels), threshold mapping to
+BUY/SELL/NEUTRAL, and signal confirmation/contradiction blocking.
+"""
+
+import math
+
+import pytest
+
+from trading.signals.order_flow import (
+    confirm_signal_with_flow,
+    order_book_imbalance,
+    order_flow_signal,
+)
+
+
+def make_book(bid_qtys, ask_qtys, price=100.0):
+    """Build a Binance-shaped order book from per-level quantities."""
+    bids = [[price - i, qty] for i, qty in enumerate(bid_qtys)]
+    asks = [[price + 1 + i, qty] for i, qty in enumerate(ask_qtys)]
+    return {"bids": bids, "asks": asks}
+
+
+class TestOrderBookImbalance:
+    def test_balanced_book_is_zero(self):
+        book = make_book([1.0, 2.0, 3.0], [3.0, 2.0, 1.0])
+        assert order_book_imbalance(book) == pytest.approx(0.0)
+
+    def test_bid_heavy_book_is_positive(self):
+        book = make_book([3.0], [1.0])
+        assert order_book_imbalance(book) == pytest.approx(0.5)
+
+    def test_ask_heavy_book_is_negative(self):
+        book = make_book([1.0], [3.0])
+        assert order_book_imbalance(book) == pytest.approx(-0.5)
+
+    def test_only_bids_hits_upper_bound(self):
+        book = {"bids": [[100.0, 5.0]], "asks": []}
+        assert order_book_imbalance(book) == pytest.approx(1.0)
+
+    def test_only_asks_hits_lower_bound(self):
+        book = {"bids": [], "asks": [[101.0, 5.0]]}
+        assert order_book_imbalance(book) == pytest.approx(-1.0)
+
+    def test_empty_book_paper_mode(self):
+        assert order_book_imbalance({"bids": [], "asks": []}) == 0.0
+
+    def test_missing_keys(self):
+        assert order_book_imbalance({}) == 0.0
+
+    def test_none_book(self):
+        assert order_book_imbalance(None) == 0.0
+
+    def test_non_mapping_book(self):
+        assert order_book_imbalance([["100", "1"]]) == 0.0  # type: ignore[arg-type]
+
+    def test_string_quantities_binance_rest(self):
+        book = {
+            "bids": [["100.0", "3.0"], ["99.5", "1.0"]],
+            "asks": [["100.5", "1.0"], ["101.0", "1.0"]],
+        }
+        # bid_liq=4, ask_liq=2 -> (4-2)/6
+        assert order_book_imbalance(book) == pytest.approx(2.0 / 6.0)
+
+    def test_depth_truncation(self):
+        # Deep bid liquidity beyond the requested depth must be ignored.
+        book = make_book([1.0, 1.0, 100.0], [1.0, 1.0])
+        assert order_book_imbalance(book, depth=2) == pytest.approx(0.0)
+        # Full depth sees the large third bid level.
+        assert order_book_imbalance(book, depth=10) > 0.9
+
+    def test_zero_or_negative_depth_is_neutral(self):
+        book = make_book([5.0], [1.0])
+        assert order_book_imbalance(book, depth=0) == 0.0
+        assert order_book_imbalance(book, depth=-3) == 0.0
+
+    def test_malformed_levels_are_skipped(self):
+        book = {
+            "bids": [["100.0", "2.0"], ["bad"], None, ["99.0", "not-a-number"]],
+            "asks": [["101.0", "1.0"], 42],
+        }
+        # Only the two valid levels count: (2-1)/3
+        assert order_book_imbalance(book) == pytest.approx(1.0 / 3.0)
+
+    def test_nan_and_negative_quantities_are_skipped(self):
+        book = {
+            "bids": [[100.0, float("nan")], [99.0, -5.0], [98.0, 2.0]],
+            "asks": [[101.0, 2.0]],
+        }
+        assert order_book_imbalance(book) == pytest.approx(0.0)
+
+    def test_zero_quantities_are_neutral(self):
+        book = {"bids": [[100.0, 0.0]], "asks": [[101.0, 0.0]]}
+        assert order_book_imbalance(book) == 0.0
+
+    def test_result_within_bounds(self):
+        book = make_book([10.0, 20.0, 0.5], [0.1, 7.0])
+        assert -1.0 <= order_book_imbalance(book) <= 1.0
+
+
+class TestOrderFlowSignal:
+    def test_buy_above_threshold(self):
+        assert order_flow_signal(0.5) == "BUY"
+
+    def test_sell_below_negative_threshold(self):
+        assert order_flow_signal(-0.5) == "SELL"
+
+    def test_neutral_inside_band(self):
+        assert order_flow_signal(0.0) == "NEUTRAL"
+        assert order_flow_signal(0.1) == "NEUTRAL"
+        assert order_flow_signal(-0.1) == "NEUTRAL"
+
+    def test_exact_threshold_is_neutral(self):
+        assert order_flow_signal(0.15) == "NEUTRAL"
+        assert order_flow_signal(-0.15) == "NEUTRAL"
+
+    def test_just_past_threshold_is_directional(self):
+        assert order_flow_signal(0.150001) == "BUY"
+        assert order_flow_signal(-0.150001) == "SELL"
+
+    def test_custom_threshold(self):
+        assert order_flow_signal(0.2, threshold=0.3) == "NEUTRAL"
+        assert order_flow_signal(0.2, threshold=0.1) == "BUY"
+
+    def test_nan_is_neutral(self):
+        assert order_flow_signal(float("nan")) == "NEUTRAL"
+
+    def test_non_numeric_is_neutral(self):
+        assert order_flow_signal(None) == "NEUTRAL"  # type: ignore[arg-type]
+        assert order_flow_signal("oops") == "NEUTRAL"  # type: ignore[arg-type]
+
+    def test_extreme_values(self):
+        assert order_flow_signal(1.0) == "BUY"
+        assert order_flow_signal(-1.0) == "SELL"
+
+
+class TestConfirmSignalWithFlow:
+    def test_buy_confirmed_by_bid_heavy_book(self):
+        book = make_book([3.0], [1.0])
+        confirmed, imbalance = confirm_signal_with_flow("BUY", book)
+        assert confirmed is True
+        assert imbalance == pytest.approx(0.5)
+
+    def test_buy_blocked_by_ask_heavy_book(self):
+        book = make_book([1.0], [3.0])
+        confirmed, imbalance = confirm_signal_with_flow("BUY", book)
+        assert confirmed is False
+        assert imbalance == pytest.approx(-0.5)
+
+    def test_sell_confirmed_by_ask_heavy_book(self):
+        book = make_book([1.0], [3.0])
+        confirmed, imbalance = confirm_signal_with_flow("SELL", book)
+        assert confirmed is True
+        assert imbalance == pytest.approx(-0.5)
+
+    def test_sell_blocked_by_bid_heavy_book(self):
+        book = make_book([3.0], [1.0])
+        confirmed, imbalance = confirm_signal_with_flow("SELL", book)
+        assert confirmed is False
+        assert imbalance == pytest.approx(0.5)
+
+    def test_neutral_flow_never_blocks(self):
+        balanced = make_book([1.0], [1.0])
+        for signal in ("BUY", "SELL"):
+            confirmed, imbalance = confirm_signal_with_flow(signal, balanced)
+            assert confirmed is True
+            assert imbalance == pytest.approx(0.0)
+
+    def test_empty_book_paper_mode_never_blocks(self):
+        empty = {"bids": [], "asks": []}
+        for signal in ("BUY", "SELL"):
+            confirmed, imbalance = confirm_signal_with_flow(signal, empty)
+            assert confirmed is True
+            assert imbalance == 0.0
+
+    def test_none_book_never_blocks(self):
+        confirmed, imbalance = confirm_signal_with_flow("BUY", None)
+        assert confirmed is True
+        assert imbalance == 0.0
+
+    def test_non_directional_signal_always_confirmed(self):
+        bid_heavy = make_book([3.0], [1.0])
+        confirmed, imbalance = confirm_signal_with_flow("HOLD", bid_heavy)
+        assert confirmed is True
+        assert imbalance == pytest.approx(0.5)
+
+    def test_signal_case_insensitive(self):
+        ask_heavy = make_book([1.0], [3.0])
+        confirmed, _ = confirm_signal_with_flow("buy", ask_heavy)
+        assert confirmed is False
+        confirmed, _ = confirm_signal_with_flow(" sell ", ask_heavy)
+        assert confirmed is True
+
+    def test_custom_threshold_widens_neutral_band(self):
+        # imbalance = -0.5: blocks BUY at default threshold, passes at 0.6.
+        ask_heavy = make_book([1.0], [3.0])
+        confirmed, _ = confirm_signal_with_flow("BUY", ask_heavy, threshold=0.6)
+        assert confirmed is True
+
+    def test_returns_tuple_of_bool_and_float(self):
+        result = confirm_signal_with_flow("BUY", make_book([2.0], [1.0]))
+        assert isinstance(result, tuple)
+        assert isinstance(result[0], bool)
+        assert isinstance(result[1], float)
+        assert not math.isnan(result[1])

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -1,0 +1,253 @@
+"""
+Tests for trading.risk.position_sizing (roadmap items #3 and #13).
+
+Covers the happy paths, the exact Kelly formula on a pinned case, clamping at
+both bounds, and defensive behavior on empty/short/NaN/degenerate inputs.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading.risk.position_sizing import (
+    kelly_fraction,
+    kelly_from_trades,
+    volume_multiplier,
+)
+
+
+def make_volume_df(volumes) -> pd.DataFrame:
+    """Build a minimal OHLCV-ish DataFrame with the given volume column."""
+    n = len(volumes)
+    return pd.DataFrame(
+        {
+            "close": [100.0] * n,
+            "volume": volumes,
+        }
+    )
+
+
+class TestVolumeMultiplier:
+    def test_happy_path_ratio_within_bounds(self):
+        # 19 bars at 100, current bar at 150: mean = (19*100 + 150) / 20
+        df = make_volume_df([100.0] * 19 + [150.0])
+        expected = 150.0 / ((19 * 100.0 + 150.0) / 20)
+        assert volume_multiplier(df, window=20) == pytest.approx(expected)
+
+    def test_flat_volume_is_exactly_one(self):
+        df = make_volume_df([250.0] * 30)
+        assert volume_multiplier(df, window=20) == pytest.approx(1.0)
+
+    def test_spike_clamped_to_cap(self):
+        df = make_volume_df([100.0] * 19 + [10_000.0])
+        assert volume_multiplier(df, window=20, cap=2.0) == 2.0
+
+    def test_dry_volume_clamped_to_floor(self):
+        df = make_volume_df([100.0] * 19 + [1.0])
+        assert volume_multiplier(df, window=20, floor=0.5) == 0.5
+
+    def test_custom_bounds_respected(self):
+        df = make_volume_df([100.0] * 19 + [10_000.0])
+        assert volume_multiplier(df, window=20, floor=0.8, cap=1.5) == 1.5
+
+    def test_uses_only_last_window_bars(self):
+        # Huge old volumes outside the window must not affect the ratio.
+        df = make_volume_df([1e9] * 50 + [100.0] * 20)
+        assert volume_multiplier(df, window=20) == pytest.approx(1.0)
+
+    def test_none_input_is_neutral(self):
+        assert volume_multiplier(None) == 1.0
+
+    def test_empty_dataframe_is_neutral(self):
+        assert volume_multiplier(pd.DataFrame()) == 1.0
+
+    def test_missing_volume_column_is_neutral(self):
+        df = pd.DataFrame({"close": [1.0, 2.0, 3.0]})
+        assert volume_multiplier(df) == 1.0
+
+    def test_short_data_is_neutral(self):
+        df = make_volume_df([100.0] * 5)
+        assert volume_multiplier(df, window=20) == 1.0
+
+    def test_exactly_window_rows_is_computed(self):
+        df = make_volume_df([100.0] * 20)
+        assert volume_multiplier(df, window=20) == pytest.approx(1.0)
+
+    def test_nan_rows_reduce_valid_sample_to_neutral(self):
+        # 20 rows but only 15 valid -> not enough evidence -> neutral.
+        df = make_volume_df([100.0] * 15 + [np.nan] * 5)
+        assert volume_multiplier(df, window=20) == 1.0
+
+    def test_nan_rows_skipped_when_enough_valid_data(self):
+        # 25 valid rows among NaNs: last 20 valid are used.
+        volumes = [100.0, np.nan] * 24 + [150.0, np.nan]
+        df = make_volume_df(volumes)
+        expected = 150.0 / ((19 * 100.0 + 150.0) / 20)
+        assert volume_multiplier(df, window=20) == pytest.approx(expected)
+
+    def test_all_zero_volume_is_neutral(self):
+        df = make_volume_df([0.0] * 30)
+        assert volume_multiplier(df, window=20) == 1.0
+
+    def test_negative_current_volume_is_neutral(self):
+        df = make_volume_df([100.0] * 19 + [-5.0])
+        assert volume_multiplier(df, window=20) == 1.0
+
+    def test_non_numeric_volume_is_neutral(self):
+        df = make_volume_df(["oops"] * 30)
+        assert volume_multiplier(df, window=20) == 1.0
+
+    def test_invalid_window_is_neutral(self):
+        df = make_volume_df([100.0] * 30)
+        assert volume_multiplier(df, window=0) == 1.0
+
+    def test_case_insensitive_volume_column(self):
+        df = pd.DataFrame({"Volume": [100.0] * 19 + [150.0]})
+        expected = 150.0 / ((19 * 100.0 + 150.0) / 20)
+        assert volume_multiplier(df, window=20) == pytest.approx(expected)
+
+    def test_result_is_float(self):
+        df = make_volume_df([100] * 30)  # integer volumes
+        result = volume_multiplier(df, window=20)
+        assert isinstance(result, float)
+
+
+class TestKellyFraction:
+    def test_pinned_formula_case_clamped_to_cap(self):
+        # p=0.45, avg_win=50, avg_loss=-20 -> b=2.5
+        # f* = (2.5*0.45 - 0.55) / 2.5 = 0.23 -> clamped to cap 0.05
+        assert kelly_fraction(0.45, 50.0, -20.0) == pytest.approx(0.05)
+
+    def test_pinned_formula_case_unclamped(self):
+        # p=0.52, b=1 -> f* = (0.52 - 0.48) / 1 = 0.04, inside [0.01, 0.05]
+        assert kelly_fraction(0.52, 25.0, -25.0) == pytest.approx(0.04)
+
+    def test_exact_formula_with_wide_bounds(self):
+        # Widen the clamp so the raw formula value is observable.
+        p, avg_win, avg_loss = 0.45, 50.0, -20.0
+        b = abs(avg_win / avg_loss)
+        expected = (b * p - (1 - p)) / b  # 0.23
+        result = kelly_fraction(p, avg_win, avg_loss, floor=0.0, cap=1.0)
+        assert result == pytest.approx(expected)
+        assert result == pytest.approx(0.23)
+
+    def test_negative_edge_clamped_to_floor(self):
+        # Losing system: f* < 0 -> floor.
+        assert kelly_fraction(0.30, 20.0, -40.0) == 0.01
+
+    def test_positive_avg_loss_uses_magnitude(self):
+        # Sign convention of avg_loss must not matter.
+        assert kelly_fraction(0.45, 50.0, 20.0) == kelly_fraction(0.45, 50.0, -20.0)
+
+    def test_zero_avg_loss_returns_floor(self):
+        assert kelly_fraction(0.60, 50.0, 0.0) == 0.01
+
+    def test_zero_avg_win_returns_floor(self):
+        # b == 0 -> degenerate.
+        assert kelly_fraction(0.60, 0.0, -20.0) == 0.01
+
+    @pytest.mark.parametrize("win_rate", [0.0, 1.0, -0.2, 1.5])
+    def test_win_rate_outside_open_interval_returns_floor(self, win_rate):
+        assert kelly_fraction(win_rate, 50.0, -20.0) == 0.01
+
+    @pytest.mark.parametrize(
+        "win_rate,avg_win,avg_loss",
+        [
+            (math.nan, 50.0, -20.0),
+            (0.5, math.nan, -20.0),
+            (0.5, 50.0, math.nan),
+            (math.inf, 50.0, -20.0),
+            (0.5, math.inf, -20.0),
+        ],
+    )
+    def test_non_finite_inputs_return_floor(self, win_rate, avg_win, avg_loss):
+        assert kelly_fraction(win_rate, avg_win, avg_loss) == 0.01
+
+    def test_non_numeric_inputs_return_floor(self):
+        assert kelly_fraction(None, 50.0, -20.0) == 0.01
+        assert kelly_fraction("high", 50.0, -20.0) == 0.01
+
+    def test_custom_floor_and_cap(self):
+        assert kelly_fraction(0.45, 50.0, -20.0, floor=0.02, cap=0.10) == 0.10
+        assert kelly_fraction(0.30, 20.0, -40.0, floor=0.02, cap=0.10) == 0.02
+
+    def test_result_always_within_bounds(self):
+        for p in np.linspace(0.05, 0.95, 19):
+            result = kelly_fraction(float(p), 30.0, -25.0)
+            assert 0.01 <= result <= 0.05
+
+
+class TestKellyFromTrades:
+    @staticmethod
+    def make_trades(n_wins: int, n_losses: int, win: float, loss: float):
+        return [{"pnl": win}] * n_wins + [{"pnl": loss}] * n_losses
+
+    def test_happy_path_matches_kelly_fraction(self):
+        # 9 wins of +50, 11 losses of -20 -> p=0.45, b=2.5 -> cap 0.05.
+        trades = self.make_trades(9, 11, 50.0, -20.0)
+        assert len(trades) == 20
+        assert kelly_from_trades(trades) == pytest.approx(
+            kelly_fraction(0.45, 50.0, -20.0)
+        )
+        assert kelly_from_trades(trades) == pytest.approx(0.05)
+
+    def test_stats_derived_correctly_with_wide_bounds(self):
+        # Mixed magnitudes: p=0.5, avg_win=40, avg_loss=-20 -> b=2
+        # f* = (2*0.5 - 0.5) / 2 = 0.25.
+        trades = self.make_trades(5, 10, 30.0, -20.0) + self.make_trades(
+            5, 0, 50.0, 0.0
+        )
+        assert kelly_from_trades(trades, floor=0.0, cap=1.0) == pytest.approx(0.25)
+
+    def test_fewer_than_min_trades_returns_floor(self):
+        trades = self.make_trades(10, 9, 50.0, -20.0)  # 19 < 20
+        assert kelly_from_trades(trades) == 0.01
+
+    def test_min_trades_boundary(self):
+        trades = self.make_trades(9, 11, 50.0, -20.0)  # exactly 20
+        assert kelly_from_trades(trades, min_trades=20) == pytest.approx(0.05)
+        assert kelly_from_trades(trades, min_trades=21) == 0.01
+
+    def test_empty_and_none_return_floor(self):
+        assert kelly_from_trades([]) == 0.01
+        assert kelly_from_trades(None) == 0.01
+
+    def test_custom_floor_propagates_to_short_history(self):
+        assert kelly_from_trades([], floor=0.02) == 0.02
+        assert kelly_from_trades([{"pnl": 5.0}], floor=0.02) == 0.02
+
+    def test_all_wins_returns_floor(self):
+        trades = self.make_trades(25, 0, 50.0, 0.0)
+        assert kelly_from_trades(trades) == 0.01
+
+    def test_all_losses_returns_floor(self):
+        trades = self.make_trades(0, 25, 0.0, -20.0)
+        assert kelly_from_trades(trades) == 0.01
+
+    def test_invalid_records_are_skipped(self):
+        trades = self.make_trades(9, 11, 50.0, -20.0)
+        junk = [
+            {"pnl": None},
+            {"pnl": "oops"},
+            {"pnl": math.nan},
+            {"amount": 3.0},  # missing 'pnl'
+            "not-a-dict",
+            None,
+        ]
+        assert kelly_from_trades(trades + junk) == pytest.approx(0.05)
+
+    def test_junk_only_history_returns_floor(self):
+        junk = [{"pnl": math.nan}] * 30
+        assert kelly_from_trades(junk) == 0.01
+
+    def test_zero_pnl_trades_count_toward_sample_not_sides(self):
+        # 9 wins, 11 losses, 5 break-even -> p = 9/25 = 0.36, b = 2.5
+        # f* = (2.5*0.36 - 0.64) / 2.5 = 0.104
+        trades = self.make_trades(9, 11, 50.0, -20.0) + [{"pnl": 0.0}] * 5
+        assert kelly_from_trades(trades, floor=0.0, cap=1.0) == pytest.approx(0.104)
+
+    def test_kwargs_forwarded_to_kelly_fraction(self):
+        trades = self.make_trades(9, 11, 50.0, -20.0)
+        assert kelly_from_trades(trades, floor=0.02, cap=0.10) == pytest.approx(0.10)

--- a/tests/test_roadmap_wiring.py
+++ b/tests/test_roadmap_wiring.py
@@ -1,0 +1,159 @@
+"""Integration-style tests for the profitability-roadmap wiring in main.py.
+
+main() is a monolithic loop, so these tests exercise the same *composition*
+main.py runs — the stage order, env-flag semantics, and cross-module data
+handoffs of its four wiring blocks — plus a tripwire pinning the
+``get_all_trades`` column order the Kelly block depends on positionally.
+"""
+
+import inspect
+import os
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading.execution.exits import TrailingStop, dynamic_take_profit
+from trading.fees.fee_gate import is_trade_viable
+from trading.risk.position_sizing import kelly_from_trades, volume_multiplier
+from trading.signals.filters import apply_signal_filters
+from trading.signals.order_flow import confirm_signal_with_flow
+
+
+def _trending_data(rows=120, start=100.0, step=0.5, volume=1000.0):
+    """Steadily rising closes with flat volume — passes momentum, no squeeze."""
+    close = np.arange(rows) * step + start
+    rng = np.random.default_rng(42)
+    return pd.DataFrame(
+        {
+            "close": close,
+            "volume": volume + rng.uniform(-5, 5, rows),
+        }
+    )
+
+
+def test_get_all_trades_pnl_column_order_pinned():
+    # main.py's Kelly block reads pnl positionally at index 6. Pin the SELECT
+    # column order in utils/paper_trade_db.get_all_trades so a schema change
+    # fails here instead of silently corrupting sizing.
+    from utils import paper_trade_db
+
+    src = inspect.getsource(paper_trade_db.get_all_trades)
+    select = re.search(r"SELECT\s+(.+?)\s+FROM", src, re.S | re.I)
+    assert select, "get_all_trades no longer contains a SELECT ... FROM"
+    columns = [c.strip() for c in select.group(1).split(",")]
+    assert columns[6] == "pnl", (
+        f"pnl moved from index 6 in get_all_trades ({columns}); "
+        "update main.py's Kelly block (_PNL_IDX) to match"
+    )
+
+
+def test_signal_gate_stage_veto_stops_downstream_trade(monkeypatch):
+    # Mirrors main.py's gate block: a filter veto downgrades to HOLD, and the
+    # execution stages (sizing/fee gate) never fire for HOLD.
+    data = _trending_data()
+    signal, confidence, reasons = apply_signal_filters(
+        "BUY", 0.8, data, rsi=85.0  # overbought -> rsi_gate veto
+    )
+    assert signal == "HOLD" and confidence == 0.0
+    assert any("rsi" in r.lower() for r in reasons)
+    # main.py only runs order-flow/sizing/fee stages for BUY/SELL:
+    assert signal not in ("BUY", "SELL")
+
+
+def test_full_happy_path_pipeline_in_main_py_order():
+    # Stage order exactly as wired: filters -> order flow -> volume sizing ->
+    # Kelly cap -> fee gate -> (position loop) trailing stop + dynamic TP.
+    from datetime import datetime, timezone
+
+    data = _trending_data()
+    current_price = float(data["close"].iloc[-1])
+
+    # 1. signal gates pass on clean trending data (inject an in-hours time —
+    #    main.py uses the real clock, tests must not depend on when they run)
+    in_hours = datetime(2026, 7, 12, 15, 0, tzinfo=timezone.utc)
+    signal, confidence, reasons = apply_signal_filters(
+        "BUY", 0.8, data, rsi=55.0, now=in_hours
+    )
+    assert signal == "BUY" and not reasons
+
+    # 2. order flow: paper-mode empty book must NOT block (neutral)
+    ok, imbalance = confirm_signal_with_flow(signal, {"bids": [], "asks": []})
+    assert ok and imbalance == 0.0
+
+    # 3. volume sizing on ~flat volume stays near neutral
+    position_size = (100.0 / current_price) * volume_multiplier(data)
+    assert position_size > 0
+
+    # 4. Kelly cap from paper-trade rows shaped like get_all_trades output
+    rows = [
+        (i, "2026-07-12", "BTCUSDT", "BUY", 100.0, 0.1, pnl, 0.01)
+        for i, pnl in enumerate([12.0, -5.0] * 15)  # 30 trades, mixed
+    ]
+    kelly_f = kelly_from_trades([{"pnl": t[6]} for t in rows])
+    assert 0.01 <= kelly_f <= 0.05
+
+    # 5. fee gate: regime take-profit target must clear all-in costs
+    tp_price = dynamic_take_profit("TRENDING", current_price, side="BUY")
+    viable, net, costs = is_trade_viable(
+        current_price, tp_price, position_size, side="BUY"
+    )
+    assert viable and net > 0 and costs["total"] > 0
+
+    # 6. position loop: trailing stop ratchets then closes on 2% giveback,
+    #    and the dynamic TP threshold replaces the fixed $8
+    trail = TrailingStop(trail_pct=0.02)
+    closed, _ = trail.update("pos-1", "BUY", current_price, current_price * 1.05)
+    assert not closed  # new high, ratchet up
+    closed, stop = trail.update("pos-1", "BUY", current_price, current_price * 1.02)
+    assert closed and stop == pytest.approx(current_price * 1.05 * 0.98)
+    tp_threshold_usd = abs(tp_price - current_price) * position_size
+    assert tp_threshold_usd > 0  # replaces the fixed 8.0 like main.py does
+
+
+def test_fee_gate_rejects_sub_breakeven_move():
+    # Fee breakeven is ~0.09% of notional (2x 0.04% taker + 0.01% funding).
+    # A 0.05% expected move is below it -> main.py sets HOLD; the tightest
+    # regime target (CHOPPY, 0.10%) sits just ABOVE breakeven and stays viable.
+    entry = 100_000.0
+    viable, net, _ = is_trade_viable(entry, entry * 1.0005, 0.001, side="BUY")
+    assert not viable and net <= 0
+    choppy_tp = dynamic_take_profit("CHOPPY", entry, side="BUY")
+    choppy_viable, choppy_net, _ = is_trade_viable(entry, choppy_tp, 0.001, side="BUY")
+    assert choppy_viable and choppy_net == pytest.approx(0.01, abs=1e-6)
+
+
+def test_env_flag_semantics_match_main_py(monkeypatch):
+    # main.py gates every stage on os.getenv(flag, default) == "1".
+    monkeypatch.setenv("ELVIS_ROADMAP_FILTERS", "0")
+    assert os.getenv("ELVIS_ROADMAP_FILTERS", "1") != "1"  # stage skipped
+    monkeypatch.delenv("ELVIS_ROADMAP_FILTERS", raising=False)
+    assert os.getenv("ELVIS_ROADMAP_FILTERS", "1") == "1"  # default on
+    assert os.getenv("ELVIS_ORDER_FLOW", "0") != "1"  # default off
+    assert os.getenv("ELVIS_KELLY_SIZING", "0") != "1"  # default off
+    assert os.getenv("ELVIS_MTF", "0") != "1"  # default off
+
+
+def test_main_py_wiring_blocks_present():
+    # Cheap structural tripwire: the four wiring blocks and their flags exist
+    # in main.py (guards against accidental deletion in the 2400-line loop).
+    src = open("main.py").read()
+    for marker in (
+        "PROFITABILITY-ROADMAP SIGNAL GATES",
+        "ELVIS_ROADMAP_FILTERS",
+        "ELVIS_VOLUME_SIZING",
+        "ELVIS_KELLY_SIZING",
+        "ELVIS_FEE_GATE",
+        "ELVIS_TRAILING_STOP",
+        "ELVIS_DYNAMIC_TP",
+        "_last_regime",
+        "_PNL_IDX = 6",
+    ):
+        assert marker in src, f"main.py wiring marker missing: {marker}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_signal_filters.py
+++ b/tests/test_signal_filters.py
@@ -1,0 +1,430 @@
+"""Tests for trading/signals/filters.py (roadmap items #2, #6-#9).
+
+Plain pytest + numpy + pandas only (no torch/talib/network) so the suite
+runs in CI where heavy ML dependencies are absent.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading.signals.filters import (
+    DEFAULT_FILTER_CONFIG,
+    apply_signal_filters,
+    detect_bb_squeeze,
+    detect_macd_divergence,
+    has_momentum,
+    is_optimal_trading_hour,
+    rsi_gate,
+)
+
+OPTIMAL_NOW = datetime(2026, 7, 10, 15, 0, tzinfo=timezone.utc)
+OFF_HOURS_NOW = datetime(2026, 7, 10, 3, 0, tzinfo=timezone.utc)
+
+
+def make_df(closes, macd_histogram=None):
+    """Build a candle DataFrame with close/volume (+ optional histogram)."""
+    frame = {
+        "close": list(closes),
+        "volume": [1000.0] * len(closes),
+    }
+    if macd_histogram is not None:
+        frame["macd_histogram"] = list(macd_histogram)
+    return pd.DataFrame(frame)
+
+
+def high_then_low_vol_closes():
+    """60 closes: 30 high-volatility bars then 30 near-flat bars (squeeze)."""
+    high = [100.0 + (5.0 if i % 2 == 0 else -5.0) for i in range(30)]
+    low = [100.0 + (0.05 if i % 2 == 0 else -0.05) for i in range(30)]
+    return high + low
+
+
+# ---------------------------------------------------------------------------
+# rsi_gate (item #2)
+# ---------------------------------------------------------------------------
+
+
+class TestRsiGate:
+    def test_buy_blocked_when_overbought(self):
+        signal, reason = rsi_gate("BUY", 75.0)
+        assert signal == "HOLD"
+        assert reason is not None and "rsi_gate" in reason
+
+    def test_sell_blocked_when_oversold(self):
+        signal, reason = rsi_gate("SELL", 25.0)
+        assert signal == "HOLD"
+        assert reason is not None and "rsi_gate" in reason
+
+    def test_buy_passes_at_boundary(self):
+        # Strict comparison: exactly overbought is still allowed.
+        assert rsi_gate("BUY", 70.0) == ("BUY", None)
+
+    def test_sell_passes_at_boundary(self):
+        assert rsi_gate("SELL", 30.0) == ("SELL", None)
+
+    def test_buy_passes_in_neutral_zone(self):
+        assert rsi_gate("BUY", 50.0) == ("BUY", None)
+
+    def test_sell_passes_when_overbought(self):
+        # Selling into overbought is fine (that is the point of the trade).
+        assert rsi_gate("SELL", 80.0) == ("SELL", None)
+
+    def test_hold_unaffected(self):
+        assert rsi_gate("HOLD", 99.0) == ("HOLD", None)
+
+    def test_none_rsi_passes(self):
+        assert rsi_gate("BUY", None) == ("BUY", None)
+
+    def test_nan_rsi_passes(self):
+        assert rsi_gate("BUY", float("nan")) == ("BUY", None)
+
+    def test_custom_thresholds(self):
+        assert rsi_gate("BUY", 65.0, overbought=60.0)[0] == "HOLD"
+        assert rsi_gate("SELL", 38.0, oversold=40.0)[0] == "HOLD"
+
+    def test_lowercase_signal_normalized(self):
+        assert rsi_gate("buy", 50.0) == ("BUY", None)
+
+    def test_unknown_signal_treated_as_hold(self):
+        assert rsi_gate("FOO", 50.0) == ("HOLD", None)
+
+
+# ---------------------------------------------------------------------------
+# has_momentum (item #6)
+# ---------------------------------------------------------------------------
+
+
+class TestHasMomentum:
+    def test_rising_closes_confirm_buy(self):
+        assert has_momentum(make_df([100.0, 101.0, 102.0]), "BUY") is True
+
+    def test_falling_closes_confirm_sell(self):
+        assert has_momentum(make_df([102.0, 101.0, 100.0]), "SELL") is True
+
+    def test_flat_last_bar_fails_buy(self):
+        assert has_momentum(make_df([100.0, 101.0, 101.0]), "BUY") is False
+
+    def test_falling_closes_fail_buy(self):
+        assert has_momentum(make_df([102.0, 101.0, 100.0]), "BUY") is False
+
+    def test_short_data_returns_false(self):
+        # Needs bars + 1 = 3 closes; only 2 available.
+        assert has_momentum(make_df([100.0, 101.0]), "BUY") is False
+
+    def test_empty_dataframe_returns_false(self):
+        assert has_momentum(pd.DataFrame(), "BUY") is False
+
+    def test_missing_close_column_returns_false(self):
+        df = pd.DataFrame({"volume": [1.0, 2.0, 3.0]})
+        assert has_momentum(df, "BUY") is False
+
+    def test_nan_close_returns_false(self):
+        assert has_momentum(make_df([100.0, np.nan, 102.0]), "BUY") is False
+
+    def test_custom_bars(self):
+        df = make_df([100.0, 101.0, 102.0, 103.0])
+        assert has_momentum(df, "BUY", bars=3) is True
+        # One dip inside the window breaks the streak.
+        df2 = make_df([100.0, 99.0, 102.0, 103.0])
+        assert has_momentum(df2, "BUY", bars=3) is False
+
+    def test_only_last_bars_considered(self):
+        # Earlier history falls outside the bars window and is ignored.
+        assert has_momentum(make_df([110.0, 90.0, 100.0, 101.0, 102.0]), "BUY") is True
+
+    def test_zero_bars_returns_false(self):
+        assert has_momentum(make_df([100.0, 101.0]), "BUY", bars=0) is False
+
+    def test_unknown_direction_returns_false(self):
+        assert has_momentum(make_df([100.0, 101.0, 102.0]), "SIDEWAYS") is False
+
+
+# ---------------------------------------------------------------------------
+# detect_bb_squeeze (item #7)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectBbSqueeze:
+    def test_squeeze_detected_after_volatility_contraction(self):
+        df = make_df(high_then_low_vol_closes())
+        assert detect_bb_squeeze(df) is True
+
+    def test_no_squeeze_when_volatility_expands(self):
+        df = make_df(list(reversed(high_then_low_vol_closes())))
+        assert detect_bb_squeeze(df) is False
+
+    def test_insufficient_data_returns_false(self):
+        # Needs 2 * window - 1 = 39 rows; provide fewer.
+        df = make_df(high_then_low_vol_closes()[:30])
+        assert detect_bb_squeeze(df) is False
+
+    def test_empty_dataframe_returns_false(self):
+        assert detect_bb_squeeze(pd.DataFrame()) is False
+
+    def test_missing_close_column_returns_false(self):
+        df = pd.DataFrame({"volume": np.ones(60)})
+        assert detect_bb_squeeze(df) is False
+
+    def test_constant_closes_return_false(self):
+        # Zero-width baseline must not divide-by-zero or flag a squeeze.
+        df = make_df([100.0] * 60)
+        assert detect_bb_squeeze(df) is False
+
+    def test_nan_tail_returns_false(self):
+        closes = high_then_low_vol_closes()
+        closes[-1] = np.nan
+        assert detect_bb_squeeze(make_df(closes)) is False
+
+    def test_custom_window(self):
+        # 14 high-vol + 6 low-vol bars with window=5: the width baseline
+        # still remembers the loud regime while the current width is tiny.
+        closes = [100.0 + (4.0 if i % 2 == 0 else -4.0) for i in range(14)]
+        closes += [100.0 + (0.02 if i % 2 == 0 else -0.02) for i in range(6)]
+        assert detect_bb_squeeze(make_df(closes), window=5) is True
+
+
+# ---------------------------------------------------------------------------
+# is_optimal_trading_hour (item #8)
+# ---------------------------------------------------------------------------
+
+
+class TestIsOptimalTradingHour:
+    @pytest.mark.parametrize("hour", [14, 18, 22])
+    def test_optimal_hours_true(self, hour):
+        now = datetime(2026, 7, 10, hour, 30, tzinfo=timezone.utc)
+        assert is_optimal_trading_hour(now) is True
+
+    @pytest.mark.parametrize("hour", [0, 3, 13, 23])
+    def test_off_hours_false(self, hour):
+        now = datetime(2026, 7, 10, hour, 30, tzinfo=timezone.utc)
+        assert is_optimal_trading_hour(now) is False
+
+    def test_naive_datetime_treated_as_utc(self):
+        assert is_optimal_trading_hour(datetime(2026, 7, 10, 15, 0)) is True
+        assert is_optimal_trading_hour(datetime(2026, 7, 10, 3, 0)) is False
+
+    def test_aware_non_utc_converted(self):
+        # 16:00 at UTC+3 is 13:00 UTC -> outside the window.
+        tz = timezone(timedelta(hours=3))
+        assert is_optimal_trading_hour(datetime(2026, 7, 10, 16, 0, tzinfo=tz)) is False
+        # 17:00 at UTC+3 is 14:00 UTC -> inside.
+        assert is_optimal_trading_hour(datetime(2026, 7, 10, 17, 0, tzinfo=tz)) is True
+
+    def test_custom_hours(self):
+        now = datetime(2026, 7, 10, 2, 0, tzinfo=timezone.utc)
+        assert is_optimal_trading_hour(now, optimal_hours={1, 2, 3}) is True
+
+    def test_default_now_returns_bool(self):
+        assert isinstance(is_optimal_trading_hour(), bool)
+
+
+# ---------------------------------------------------------------------------
+# detect_macd_divergence (item #9)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMacdDivergence:
+    def test_bullish_divergence(self):
+        df = make_df([101.0, 100.0], macd_histogram=[-0.5, -0.2])
+        assert detect_macd_divergence(df) == "BULLISH_DIVERGENCE"
+
+    def test_bearish_divergence(self):
+        df = make_df([100.0, 101.0], macd_histogram=[0.5, 0.2])
+        assert detect_macd_divergence(df) == "BEARISH_DIVERGENCE"
+
+    def test_no_divergence_when_aligned(self):
+        df = make_df([100.0, 101.0], macd_histogram=[0.2, 0.5])
+        assert detect_macd_divergence(df) is None
+        df = make_df([101.0, 100.0], macd_histogram=[0.5, 0.2])
+        assert detect_macd_divergence(df) is None
+
+    def test_flat_price_returns_none(self):
+        df = make_df([100.0, 100.0], macd_histogram=[0.5, 0.2])
+        assert detect_macd_divergence(df) is None
+
+    def test_flat_histogram_returns_none(self):
+        df = make_df([100.0, 101.0], macd_histogram=[0.3, 0.3])
+        assert detect_macd_divergence(df) is None
+
+    def test_single_row_returns_none(self):
+        df = make_df([100.0], macd_histogram=[0.5])
+        assert detect_macd_divergence(df) is None
+
+    def test_empty_dataframe_returns_none(self):
+        assert detect_macd_divergence(pd.DataFrame()) is None
+
+    def test_missing_histogram_column_returns_none(self):
+        assert detect_macd_divergence(make_df([101.0, 100.0])) is None
+
+    def test_nan_histogram_returns_none(self):
+        df = make_df([101.0, 100.0], macd_histogram=[np.nan, 0.2])
+        assert detect_macd_divergence(df) is None
+
+    def test_only_last_two_rows_considered(self):
+        closes = [90.0, 95.0, 101.0, 100.0]
+        hist = [1.0, 2.0, -0.5, -0.2]
+        assert detect_macd_divergence(make_df(closes, hist)) == "BULLISH_DIVERGENCE"
+
+
+# ---------------------------------------------------------------------------
+# apply_signal_filters (composite)
+# ---------------------------------------------------------------------------
+
+
+def clean_buy_df():
+    """Data that passes every filter for a BUY: no squeeze, rising closes."""
+    closes = high_then_low_vol_closes()[:40]  # expanding-vol tail -> no squeeze
+    closes = list(reversed(closes))
+    closes += [200.0, 201.0, 202.0]  # rising tail confirms BUY momentum
+    hist = list(np.linspace(-1.0, 1.0, len(closes)))  # rising hist, no bear div
+    return make_df(closes, macd_histogram=hist)
+
+
+class TestApplySignalFilters:
+    def test_clean_buy_passes_unchanged(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, clean_buy_df(), rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence, reasons) == ("BUY", 0.82, [])
+
+    def test_rsi_blocks_buy(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, clean_buy_df(), rsi=85.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert len(reasons) == 1 and "rsi_gate" in reasons[0]
+
+    def test_momentum_blocks_buy_on_falling_tape(self):
+        df = clean_buy_df()
+        df.loc[df.index[-1], "close"] = 100.0  # break the rising streak
+        df.loc[df.index[-1], "macd_histogram"] = 2.0  # keep hist rising (no div)
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, df, rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert any("momentum" in r for r in reasons)
+
+    def test_squeeze_blocks_signal(self):
+        closes = high_then_low_vol_closes()
+        closes += [100.0, 100.2, 100.4]  # rising tail, squeeze still active
+        df = make_df(closes, macd_histogram=list(np.linspace(-1, 1, len(closes))))
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, df, rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert any("bb_squeeze" in r for r in reasons)
+
+    def test_off_hours_blocks_signal(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, clean_buy_df(), rsi=50.0, now=OFF_HOURS_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert any("trading_hours" in r for r in reasons)
+
+    def test_bearish_divergence_blocks_buy(self):
+        df = clean_buy_df()
+        # Price still rising but histogram now falling -> bearish divergence.
+        df.loc[df.index[-1], "macd_histogram"] = -5.0
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, df, rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert any("BEARISH_DIVERGENCE" in r for r in reasons)
+
+    def test_multiple_reasons_collected(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, clean_buy_df(), rsi=85.0, now=OFF_HOURS_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert len(reasons) == 2
+
+    def test_disabled_filter_lets_signal_through(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY",
+            0.82,
+            clean_buy_df(),
+            rsi=50.0,
+            now=OFF_HOURS_NOW,
+            config={"trading_hours": False},
+        )
+        assert (signal, confidence, reasons) == ("BUY", 0.82, [])
+
+    def test_all_filters_disabled_passes_anything(self):
+        config = {key: False for key in DEFAULT_FILTER_CONFIG}
+        signal, confidence, reasons = apply_signal_filters(
+            "SELL", 0.6, pd.DataFrame(), rsi=1.0, now=OFF_HOURS_NOW, config=config
+        )
+        assert (signal, confidence, reasons) == ("SELL", 0.6, [])
+
+    def test_none_rsi_skips_gate(self):
+        signal, _, reasons = apply_signal_filters(
+            "BUY", 0.82, clean_buy_df(), rsi=None, now=OPTIMAL_NOW
+        )
+        assert signal == "BUY" and reasons == []
+
+    def test_empty_data_blocks_conservatively_without_raising(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY", 0.82, pd.DataFrame(), rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert any("momentum" in r for r in reasons)
+
+    def test_hold_stays_hold_without_override(self):
+        df = make_df([101.0, 100.0], macd_histogram=[-0.5, -0.2])  # bullish div
+        signal, confidence, reasons = apply_signal_filters(
+            "HOLD", 0.0, df, now=OPTIMAL_NOW
+        )
+        assert (signal, confidence, reasons) == ("HOLD", 0.0, [])
+
+    def test_override_promotes_hold_to_buy(self):
+        df = make_df([101.0, 100.0], macd_histogram=[-0.5, -0.2])  # bullish div
+        signal, confidence, reasons = apply_signal_filters(
+            "HOLD", 0.0, df, now=OPTIMAL_NOW, config={"macd_divergence_override": True}
+        )
+        assert (signal, confidence) == ("BUY", 0.75)
+        assert any("BULLISH_DIVERGENCE" in r for r in reasons)
+
+    def test_override_promotes_hold_to_sell(self):
+        df = make_df([100.0, 101.0], macd_histogram=[0.5, 0.2])  # bearish div
+        signal, confidence, reasons = apply_signal_filters(
+            "HOLD", 0.0, df, now=OPTIMAL_NOW, config={"macd_divergence_override": True}
+        )
+        assert (signal, confidence) == ("SELL", 0.75)
+        assert any("BEARISH_DIVERGENCE" in r for r in reasons)
+
+    def test_override_noop_without_divergence(self):
+        df = make_df([100.0, 101.0], macd_histogram=[0.2, 0.5])  # aligned
+        signal, confidence, reasons = apply_signal_filters(
+            "HOLD", 0.0, df, now=OPTIMAL_NOW, config={"macd_divergence_override": True}
+        )
+        assert (signal, confidence, reasons) == ("HOLD", 0.0, [])
+
+    def test_override_does_not_resurrect_blocked_signal(self):
+        # BUY blocked by RSI; bullish divergence present; override enabled.
+        # The block must stand: no divergence-generated re-entry.
+        df = make_df([101.0, 100.0], macd_histogram=[-0.5, -0.2])  # bullish divergence
+        signal, confidence, reasons = apply_signal_filters(
+            "BUY",
+            0.82,
+            df,
+            rsi=85.0,
+            now=OPTIMAL_NOW,
+            config={"macd_divergence_override": True},
+        )
+        assert (signal, confidence) == ("HOLD", 0.0)
+        assert reasons  # veto reasons recorded, no override applied
+
+    def test_unknown_signal_treated_as_hold(self):
+        signal, confidence, reasons = apply_signal_filters(
+            "LONG_SHOT", 0.9, clean_buy_df(), now=OPTIMAL_NOW
+        )
+        assert signal == "HOLD" and reasons == []
+
+    def test_non_numeric_confidence_coerced(self):
+        signal, confidence, _ = apply_signal_filters(
+            "BUY", None, clean_buy_df(), rsi=50.0, now=OPTIMAL_NOW
+        )
+        assert signal == "BUY" and confidence == 0.0

--- a/tests/test_walk_forward.py
+++ b/tests/test_walk_forward.py
@@ -1,0 +1,293 @@
+"""Tests for trading.optimization.walk_forward (roadmap item #15).
+
+Covers the WalkForwardOptimizer fold mechanics (train/test slicing,
+out-of-sample evaluation, determinism, guards) and the built-in
+sma_crossover_backtest, including short/NaN/degenerate inputs.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from trading.optimization.walk_forward import (
+    WalkForwardOptimizer,
+    sma_crossover_backtest,
+)
+
+
+def make_trend_data(
+    n: int = 200, slope: float = 1.0, start: float = 100.0
+) -> pd.DataFrame:
+    """Deterministic monotonic uptrend close series."""
+    close = start + slope * np.arange(n, dtype=float)
+    return pd.DataFrame({"close": close})
+
+
+def make_noisy_data(n: int = 300, seed: int = 42) -> pd.DataFrame:
+    """Seeded random-walk close series (deterministic across runs)."""
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(loc=0.0005, scale=0.01, size=n)
+    close = 100.0 * np.cumprod(1.0 + returns)
+    return pd.DataFrame({"close": close})
+
+
+# ---------------------------------------------------------------------------
+# sma_crossover_backtest
+# ---------------------------------------------------------------------------
+
+
+class TestSmaCrossoverBacktest:
+    def test_uptrend_is_profitable(self):
+        data = make_trend_data(n=200)
+        result = sma_crossover_backtest(data, {"sma_short": 5, "sma_long": 20})
+        assert result["total_return"] > 0
+        assert result["sharpe"] > 0
+
+    def test_returns_expected_keys_and_floats(self):
+        data = make_noisy_data(n=100)
+        result = sma_crossover_backtest(data, {"sma_short": 5, "sma_long": 20})
+        assert set(result) == {"sharpe", "total_return"}
+        assert all(isinstance(value, float) for value in result.values())
+        assert all(math.isfinite(value) for value in result.values())
+
+    def test_empty_data_is_neutral(self):
+        result = sma_crossover_backtest(
+            pd.DataFrame(), {"sma_short": 5, "sma_long": 20}
+        )
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+    def test_short_data_is_neutral(self):
+        data = make_trend_data(n=3)
+        result = sma_crossover_backtest(data, {"sma_short": 5, "sma_long": 20})
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+    def test_single_row_is_neutral(self):
+        data = pd.DataFrame({"close": [100.0]})
+        result = sma_crossover_backtest(data, {"sma_short": 2, "sma_long": 3})
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+    def test_missing_close_column_is_neutral(self):
+        data = pd.DataFrame({"open": [1.0, 2.0, 3.0]})
+        result = sma_crossover_backtest(data, {"sma_short": 2, "sma_long": 3})
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+    def test_nan_close_values_do_not_raise(self):
+        data = make_trend_data(n=60)
+        data.loc[10:20, "close"] = np.nan
+        result = sma_crossover_backtest(data, {"sma_short": 3, "sma_long": 10})
+        assert math.isfinite(result["sharpe"])
+        assert math.isfinite(result["total_return"])
+
+    def test_all_nan_close_is_neutral(self):
+        data = pd.DataFrame({"close": [np.nan] * 30})
+        result = sma_crossover_backtest(data, {"sma_short": 2, "sma_long": 5})
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+    def test_missing_params_are_neutral(self):
+        data = make_trend_data(n=50)
+        assert sma_crossover_backtest(data, {}) == {"sharpe": 0.0, "total_return": 0.0}
+        assert sma_crossover_backtest(data, {"sma_short": 5}) == {
+            "sharpe": 0.0,
+            "total_return": 0.0,
+        }
+
+    def test_invalid_window_values_are_neutral(self):
+        data = make_trend_data(n=50)
+        neutral = {"sharpe": 0.0, "total_return": 0.0}
+        assert sma_crossover_backtest(data, {"sma_short": 0, "sma_long": 10}) == neutral
+        assert (
+            sma_crossover_backtest(data, {"sma_short": -3, "sma_long": 10}) == neutral
+        )
+        assert (
+            sma_crossover_backtest(data, {"sma_short": "abc", "sma_long": 10})
+            == neutral
+        )
+
+    def test_constant_price_has_zero_sharpe(self):
+        data = pd.DataFrame({"close": [100.0] * 50})
+        result = sma_crossover_backtest(data, {"sma_short": 3, "sma_long": 10})
+        assert result == {"sharpe": 0.0, "total_return": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# WalkForwardOptimizer
+# ---------------------------------------------------------------------------
+
+
+class TestWalkForwardOptimizer:
+    def test_known_best_combo_wins_on_trend(self):
+        # On a monotonic uptrend the crossover goes long once SMA(long) has
+        # warmed up, so the fastest-warming combo (2, 3) is in the market
+        # longest and must win on total_return over the slow (10, 50) combo.
+        data = make_trend_data(n=240)
+        optimizer = WalkForwardOptimizer(
+            sma_crossover_backtest,
+            {"sma_short": [2, 10], "sma_long": [3, 50]},
+            metric="total_return",
+        )
+        report = optimizer.optimize(data, train_window=120, test_window=60)
+        assert report["best_params"] == {"sma_short": 2, "sma_long": 3}
+        for fold in report["folds"]:
+            assert fold["best_params"] == {"sma_short": 2, "sma_long": 3}
+            assert fold["train_metric"] > 0
+        assert report["mean_test_metric"] > 0
+
+    def test_out_of_sample_uses_test_slice(self):
+        # backtest_fn reports the first positional index of the slice it was
+        # given, so train_metric/test_metric prove exactly which rows each
+        # evaluation saw.
+        data = pd.DataFrame({"close": np.arange(100, dtype=float)})
+
+        def first_row_backtest(df: pd.DataFrame, params: dict) -> dict:
+            return {"sharpe": float(df["close"].iloc[0])}
+
+        optimizer = WalkForwardOptimizer(first_row_backtest, {"x": [1]})
+        report = optimizer.optimize(data, train_window=60, test_window=20, step=20)
+
+        assert len(report["folds"]) == 2
+        fold_one, fold_two = report["folds"]
+        assert fold_one["train_range"] == (0, 60)
+        assert fold_one["train_metric"] == 0.0  # train slice starts at row 0
+        assert fold_one["test_metric"] == 60.0  # test slice starts at row 60
+        assert fold_two["train_range"] == (20, 80)
+        assert fold_two["train_metric"] == 20.0
+        assert fold_two["test_metric"] == 80.0
+        assert report["mean_test_metric"] == pytest.approx(70.0)
+
+    def test_test_slice_has_expected_length(self):
+        seen = []
+
+        def spy_backtest(df: pd.DataFrame, params: dict) -> dict:
+            seen.append(len(df))
+            return {"sharpe": 1.0}
+
+        data = make_trend_data(n=100)
+        optimizer = WalkForwardOptimizer(spy_backtest, {"x": [1, 2]})
+        optimizer.optimize(data, train_window=60, test_window=20, step=20)
+        # Per fold: 2 train evaluations (grid) + 1 test evaluation.
+        assert seen == [60, 60, 20, 60, 60, 20]
+
+    def test_step_defaults_to_test_window(self):
+        data = make_trend_data(n=100)
+        optimizer = WalkForwardOptimizer(lambda df, p: {"sharpe": 1.0}, {"x": [1]})
+        default_step = optimizer.optimize(data, train_window=40, test_window=20)
+        explicit_step = optimizer.optimize(
+            data, train_window=40, test_window=20, step=20
+        )
+        assert len(default_step["folds"]) == len(explicit_step["folds"]) == 3
+        assert [f["train_range"] for f in default_step["folds"]] == [
+            f["train_range"] for f in explicit_step["folds"]
+        ]
+
+    def test_tiny_data_raises_value_error(self):
+        data = make_trend_data(n=10)
+        optimizer = WalkForwardOptimizer(
+            sma_crossover_backtest, {"sma_short": [2], "sma_long": [5]}
+        )
+        with pytest.raises(ValueError, match="Not enough data"):
+            optimizer.optimize(data, train_window=60, test_window=20)
+
+    def test_empty_data_raises_value_error(self):
+        optimizer = WalkForwardOptimizer(
+            sma_crossover_backtest, {"sma_short": [2], "sma_long": [5]}
+        )
+        with pytest.raises(ValueError, match="Not enough data"):
+            optimizer.optimize(pd.DataFrame(), train_window=10, test_window=5)
+
+    def test_exactly_one_fold_boundary(self):
+        data = make_trend_data(n=80)
+        optimizer = WalkForwardOptimizer(lambda df, p: {"sharpe": 1.0}, {"x": [1]})
+        report = optimizer.optimize(data, train_window=60, test_window=20)
+        assert len(report["folds"]) == 1
+        assert report["folds"][0]["train_range"] == (0, 60)
+
+    def test_invalid_windows_raise_value_error(self):
+        data = make_trend_data(n=100)
+        optimizer = WalkForwardOptimizer(lambda df, p: {"sharpe": 1.0}, {"x": [1]})
+        with pytest.raises(ValueError):
+            optimizer.optimize(data, train_window=0, test_window=20)
+        with pytest.raises(ValueError):
+            optimizer.optimize(data, train_window=20, test_window=0)
+        with pytest.raises(ValueError):
+            optimizer.optimize(data, train_window=20, test_window=10, step=0)
+
+    def test_empty_param_grid_raises(self):
+        with pytest.raises(ValueError):
+            WalkForwardOptimizer(sma_crossover_backtest, {})
+        with pytest.raises(ValueError):
+            WalkForwardOptimizer(sma_crossover_backtest, {"sma_short": []})
+
+    def test_missing_metric_scores_minus_inf(self):
+        # Combo x=1 never reports the metric -> -inf, so x=2 must win even
+        # though its metric value is tiny.
+        def partial_backtest(df: pd.DataFrame, params: dict) -> dict:
+            if params["x"] == 1:
+                return {"other_metric": 999.0}
+            return {"sharpe": 0.001}
+
+        data = make_trend_data(n=80)
+        optimizer = WalkForwardOptimizer(partial_backtest, {"x": [1, 2]})
+        report = optimizer.optimize(data, train_window=60, test_window=20)
+        assert report["best_params"] == {"x": 2}
+        assert report["folds"][0]["train_metric"] == pytest.approx(0.001)
+
+    def test_all_missing_metric_does_not_raise(self):
+        data = make_trend_data(n=80)
+        optimizer = WalkForwardOptimizer(lambda df, p: {}, {"x": [1, 2]})
+        report = optimizer.optimize(data, train_window=60, test_window=20)
+        assert report["folds"][0]["train_metric"] == float("-inf")
+        assert report["best_params"] == {"x": 1}  # deterministic first combo
+
+    def test_backtest_exception_scores_minus_inf(self):
+        def flaky_backtest(df: pd.DataFrame, params: dict) -> dict:
+            if params["x"] == 1:
+                raise RuntimeError("boom")
+            return {"sharpe": 0.5}
+
+        data = make_trend_data(n=80)
+        optimizer = WalkForwardOptimizer(flaky_backtest, {"x": [1, 2]})
+        report = optimizer.optimize(data, train_window=60, test_window=20)
+        assert report["best_params"] == {"x": 2}
+
+    def test_deterministic_across_runs(self):
+        data = make_noisy_data(n=300, seed=7)
+        grid = {"sma_short": [3, 5, 8], "sma_long": [13, 21, 34]}
+        first = WalkForwardOptimizer(sma_crossover_backtest, grid).optimize(
+            data, train_window=150, test_window=50
+        )
+        second = WalkForwardOptimizer(sma_crossover_backtest, grid).optimize(
+            data, train_window=150, test_window=50
+        )
+        assert first == second
+
+    def test_deterministic_tie_break_keeps_first_combo(self):
+        # Constant metric: every combo ties, the first itertools.product
+        # combination must win on every fold, every run.
+        data = make_trend_data(n=100)
+        grid = {"a": [1, 2], "b": [10, 20]}
+        optimizer = WalkForwardOptimizer(lambda df, p: {"sharpe": 1.0}, grid)
+        for _ in range(2):
+            report = optimizer.optimize(data, train_window=40, test_window=20)
+            for fold in report["folds"]:
+                assert fold["best_params"] == {"a": 1, "b": 10}
+
+    def test_report_structure(self):
+        data = make_noisy_data(n=200)
+        optimizer = WalkForwardOptimizer(
+            sma_crossover_backtest, {"sma_short": [3, 5], "sma_long": [10, 20]}
+        )
+        report = optimizer.optimize(data, train_window=100, test_window=40)
+        assert set(report) == {"folds", "best_params", "mean_test_metric"}
+        assert isinstance(report["mean_test_metric"], float)
+        for fold in report["folds"]:
+            assert set(fold) == {
+                "train_range",
+                "best_params",
+                "train_metric",
+                "test_metric",
+            }
+        assert report["best_params"] == report["folds"][-1]["best_params"]
+        expected_mean = np.mean([f["test_metric"] for f in report["folds"]])
+        assert report["mean_test_metric"] == pytest.approx(expected_mean)

--- a/trading/analysis/high_winrate_filter.py
+++ b/trading/analysis/high_winrate_filter.py
@@ -1,0 +1,486 @@
+"""
+High Win Rate Signal Filter - 60%+ Win Rate Optimization
+Advanced filtering system for trade quality improvement
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import ta
+
+
+class HighWinRateFilter:
+    """
+    Advanced signal filtering system designed to achieve 60%+ win rate
+    through multi-indicator confluence and market regime detection
+    """
+
+    def __init__(self, logger: logging.Logger = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+        # Fewer, bigger trades parameters
+        self.min_confidence_threshold = 0.85  # Minimum 85% confidence for trades
+        self.confluence_required = 4  # Minimum 4 out of 5 indicators must agree
+        self.volatility_threshold = 0.015  # 1.5% volatility threshold (stricter)
+
+        # Market regime parameters
+        self.trend_strength_min = 0.6  # Minimum trend strength
+        self.volume_spike_threshold = 1.5  # 1.5x average volume required
+
+        self.logger.info(
+            "🎯 Fewer, Bigger Trades Filter initialized - Target: Quality over Quantity"
+        )
+        self.logger.info(
+            f"   - Min Confidence: {self.min_confidence_threshold*100:.0f}%"
+        )
+        self.logger.info(
+            f"   - Confluence Required: {self.confluence_required}/5 indicators"
+        )
+        self.logger.info(f"   - Strategy: FEWER trades, BIGGER positions")
+
+    def analyze_signal_quality(
+        self, symbol: str, market_data: Dict, historical_data: pd.DataFrame
+    ) -> Dict:
+        """
+        Comprehensive signal quality analysis for high win rate trading
+
+        Args:
+            symbol: Trading symbol
+            market_data: Current market data
+            historical_data: Historical price data
+
+        Returns:
+            Dict with signal analysis and recommendations
+        """
+        try:
+            if historical_data.empty or len(historical_data) < 50:
+                return self._reject_signal("Insufficient data")
+
+            # 1. TECHNICAL CONFLUENCE ANALYSIS
+            confluence_score = self._calculate_technical_confluence(
+                market_data, historical_data
+            )
+
+            # 2. MARKET REGIME DETECTION
+            market_regime = self._detect_market_regime(historical_data)
+
+            # 3. VOLATILITY ANALYSIS
+            volatility_analysis = self._analyze_volatility(historical_data)
+
+            # 4. VOLUME CONFIRMATION
+            volume_confirmation = self._check_volume_confirmation(historical_data)
+
+            # 5. TIMING ANALYSIS
+            timing_score = self._analyze_market_timing()
+
+            # 6. AGGREGATE SIGNAL QUALITY
+            overall_quality = self._calculate_overall_quality(
+                confluence_score,
+                market_regime,
+                volatility_analysis,
+                volume_confirmation,
+                timing_score,
+            )
+
+            return {
+                "symbol": symbol,
+                "overall_quality": overall_quality,
+                "confidence": overall_quality["confidence"],
+                "recommendation": overall_quality["recommendation"],
+                "confluence_score": confluence_score,
+                "market_regime": market_regime,
+                "volatility_analysis": volatility_analysis,
+                "volume_confirmation": volume_confirmation,
+                "timing_score": timing_score,
+                "trade_approved": overall_quality["confidence"]
+                >= self.min_confidence_threshold,
+                "rejection_reason": overall_quality.get("rejection_reason"),
+                "timestamp": datetime.now(),
+            }
+
+        except Exception as e:
+            self.logger.error(f"Error in signal quality analysis: {e}")
+            return self._reject_signal(f"Analysis error: {e}")
+
+    def _calculate_technical_confluence(
+        self, market_data: Dict, historical_data: pd.DataFrame
+    ) -> Dict:
+        """Calculate technical indicator confluence score"""
+        try:
+            signals = []
+            reasons = []
+
+            # RSI Analysis (Avoid extremes)
+            rsi = market_data.get("rsi", 50)
+            if 30 < rsi < 70:  # Sweet spot for entries
+                signals.append(1)
+                reasons.append(f"RSI in optimal range: {rsi:.1f}")
+            elif 25 < rsi < 75:  # Acceptable range
+                signals.append(0.5)
+                reasons.append(f"RSI acceptable: {rsi:.1f}")
+            else:
+                signals.append(0)
+                reasons.append(f"RSI extreme: {rsi:.1f}")
+
+            # MACD Momentum
+            macd = market_data.get("macd", 0)
+            macd_signal = market_data.get("macd_signal", 0)
+            if abs(macd - macd_signal) > 0.001:  # Strong divergence
+                signals.append(1)
+                reasons.append("Strong MACD momentum")
+            else:
+                signals.append(0.3)
+                reasons.append("Weak MACD momentum")
+
+            # Moving Average Alignment
+            sma_20 = market_data.get("sma_20", 0)
+            sma_50 = market_data.get("sma_50", 0)
+            current_price = market_data.get("price", 0)
+
+            if sma_20 > sma_50 and current_price > sma_20:  # Bullish alignment
+                signals.append(1)
+                reasons.append("Bullish MA alignment")
+            elif sma_20 < sma_50 and current_price < sma_20:  # Bearish alignment
+                signals.append(1)
+                reasons.append("Bearish MA alignment")
+            else:
+                signals.append(0.2)
+                reasons.append("Neutral MA alignment")
+
+            # Bollinger Bands Analysis
+            bb_upper = market_data.get("bb_upper", 0)
+            bb_lower = market_data.get("bb_lower", 0)
+            bb_middle = market_data.get("bb_middle", 0)
+
+            if bb_lower < current_price < bb_upper:  # Within bands
+                signals.append(1)
+                reasons.append("Price within BB bands")
+            else:
+                signals.append(0.4)
+                reasons.append("Price outside BB bands")
+
+            # ADX Trend Strength
+            adx = market_data.get("adx", 25)
+            if adx > 25:  # Strong trend
+                signals.append(1)
+                reasons.append(f"Strong trend: ADX {adx:.1f}")
+            elif adx > 20:
+                signals.append(0.6)
+                reasons.append(f"Moderate trend: ADX {adx:.1f}")
+            else:
+                signals.append(0.2)
+                reasons.append(f"Weak trend: ADX {adx:.1f}")
+
+            confluence_score = np.mean(signals)
+            active_signals = sum(1 for s in signals if s >= 0.6)
+
+            return {
+                "score": confluence_score,
+                "active_signals": active_signals,
+                "total_signals": len(signals),
+                "confluence_met": active_signals >= self.confluence_required,
+                "individual_scores": signals,
+                "reasons": reasons,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Technical confluence calculation error: {e}")
+            return {"score": 0, "active_signals": 0, "confluence_met": False}
+
+    def _detect_market_regime(self, historical_data: pd.DataFrame) -> Dict:
+        """Detect current market regime for optimal trading conditions"""
+        try:
+            if len(historical_data) < 20:
+                return {"regime": "unknown", "strength": 0, "favorable": False}
+
+            # Calculate trend using linear regression
+            closes = historical_data["close"].tail(20)
+            x = np.arange(len(closes))
+            slope, intercept = np.polyfit(x, closes, 1)
+
+            # Normalize slope
+            avg_price = closes.mean()
+            trend_strength = abs(slope) / avg_price * 100
+
+            # Determine regime
+            if trend_strength > 2:  # Strong trend
+                regime = "trending_strong"
+                favorable = True
+            elif trend_strength > 1:  # Moderate trend
+                regime = "trending_moderate"
+                favorable = True
+            elif trend_strength > 0.5:  # Weak trend
+                regime = "trending_weak"
+                favorable = False
+            else:  # Ranging
+                regime = "ranging"
+                favorable = False
+
+            # Calculate volatility
+            returns = closes.pct_change().dropna()
+            volatility = returns.std() * np.sqrt(1440)  # Annualized for 1-min data
+
+            return {
+                "regime": regime,
+                "trend_direction": "bullish" if slope > 0 else "bearish",
+                "strength": trend_strength,
+                "volatility": volatility,
+                "favorable": favorable and volatility < 0.05,  # Not too volatile
+            }
+
+        except Exception as e:
+            self.logger.error(f"Market regime detection error: {e}")
+            return {"regime": "unknown", "strength": 0, "favorable": False}
+
+    def _analyze_volatility(self, historical_data: pd.DataFrame) -> Dict:
+        """Analyze volatility for trade timing"""
+        try:
+            if len(historical_data) < 10:
+                return {"level": "unknown", "favorable": False}
+
+            # Calculate recent volatility
+            recent_closes = historical_data["close"].tail(10)
+            returns = recent_closes.pct_change().dropna()
+            volatility = returns.std()
+
+            # Classify volatility level
+            if volatility < 0.01:  # Low volatility
+                level = "low"
+                favorable = True
+            elif volatility < 0.03:  # Normal volatility
+                level = "normal"
+                favorable = True
+            elif volatility < 0.05:  # High volatility
+                level = "high"
+                favorable = False
+            else:  # Extreme volatility
+                level = "extreme"
+                favorable = False
+
+            return {
+                "level": level,
+                "value": volatility,
+                "favorable": favorable,
+                "within_threshold": volatility <= self.volatility_threshold,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Volatility analysis error: {e}")
+            return {"level": "unknown", "favorable": False}
+
+    def _check_volume_confirmation(self, historical_data: pd.DataFrame) -> Dict:
+        """Check volume confirmation for signal strength"""
+        try:
+            if len(historical_data) < 5:
+                return {"confirmed": False, "ratio": 0}
+
+            # Compare recent volume to average
+            recent_volume = historical_data["volume"].tail(3).mean()
+            avg_volume = historical_data["volume"].tail(20).mean()
+            volume_ratio = recent_volume / avg_volume if avg_volume > 0 else 1
+
+            confirmed = volume_ratio >= self.volume_spike_threshold
+
+            return {
+                "confirmed": confirmed,
+                "ratio": volume_ratio,
+                "recent_volume": recent_volume,
+                "average_volume": avg_volume,
+                "threshold_met": volume_ratio >= self.volume_spike_threshold,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Volume confirmation error: {e}")
+            return {"confirmed": False, "ratio": 0}
+
+    def _analyze_market_timing(self) -> Dict:
+        """Analyze optimal market timing"""
+        try:
+            now = datetime.now()
+            hour = now.hour
+
+            # Define optimal trading hours (UTC)
+            optimal_hours = [7, 8, 9, 13, 14, 15, 16, 17]  # High liquidity periods
+            avoid_hours = [22, 23, 0, 1, 2, 3, 4, 5]  # Low liquidity periods
+
+            if hour in optimal_hours:
+                timing_score = 1.0
+                session = "optimal"
+            elif hour in avoid_hours:
+                timing_score = 0.2
+                session = "avoid"
+            else:
+                timing_score = 0.6
+                session = "acceptable"
+
+            return {
+                "score": timing_score,
+                "session": session,
+                "hour": hour,
+                "favorable": timing_score >= 0.6,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Market timing analysis error: {e}")
+            return {"score": 0.5, "session": "unknown", "favorable": False}
+
+    def _calculate_overall_quality(
+        self,
+        confluence_score: Dict,
+        market_regime: Dict,
+        volatility_analysis: Dict,
+        volume_confirmation: Dict,
+        timing_score: Dict,
+    ) -> Dict:
+        """Calculate overall signal quality and recommendation"""
+        try:
+            # Weight different factors
+            weights = {
+                "confluence": 0.40,  # 40% - Most important
+                "regime": 0.25,  # 25% - Market conditions
+                "volatility": 0.15,  # 15% - Risk management
+                "volume": 0.10,  # 10% - Confirmation
+                "timing": 0.10,  # 10% - Market timing
+            }
+
+            # Calculate weighted score
+            confluence_component = (
+                confluence_score.get("score", 0) * weights["confluence"]
+            )
+            regime_component = (
+                (market_regime.get("strength", 0) / 3) * weights["regime"]
+                if market_regime.get("favorable")
+                else 0
+            )
+            volatility_component = (
+                1 if volatility_analysis.get("favorable") else 0.3
+            ) * weights["volatility"]
+            volume_component = (
+                1 if volume_confirmation.get("confirmed") else 0.5
+            ) * weights["volume"]
+            timing_component = timing_score.get("score", 0.5) * weights["timing"]
+
+            overall_confidence = (
+                confluence_component
+                + regime_component
+                + volatility_component
+                + volume_component
+                + timing_component
+            )
+
+            # Determine recommendation
+            if overall_confidence >= 0.75:
+                recommendation = "STRONG_BUY" if overall_confidence >= 0.85 else "BUY"
+                approved = True
+                rejection_reason = None
+            elif overall_confidence >= 0.60:
+                recommendation = "WEAK_BUY"
+                approved = False
+                rejection_reason = "Confidence below threshold"
+            else:
+                recommendation = "REJECT"
+                approved = False
+                rejection_reason = f"Low quality signal: {overall_confidence:.2f}"
+
+            # Additional rejection criteria
+            if not confluence_score.get("confluence_met", False):
+                recommendation = "REJECT"
+                approved = False
+                rejection_reason = "Insufficient confluence"
+
+            if not market_regime.get("favorable", False):
+                recommendation = "REJECT"
+                approved = False
+                rejection_reason = "Unfavorable market regime"
+
+            return {
+                "confidence": overall_confidence,
+                "recommendation": recommendation,
+                "approved": approved,
+                "rejection_reason": rejection_reason,
+                "components": {
+                    "confluence": confluence_component,
+                    "regime": regime_component,
+                    "volatility": volatility_component,
+                    "volume": volume_component,
+                    "timing": timing_component,
+                },
+                "weights": weights,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Overall quality calculation error: {e}")
+            return {
+                "confidence": 0,
+                "recommendation": "REJECT",
+                "approved": False,
+                "rejection_reason": f"Calculation error: {e}",
+            }
+
+    def _reject_signal(self, reason: str) -> Dict:
+        """Return a rejected signal with reason"""
+        return {
+            "overall_quality": {
+                "confidence": 0,
+                "recommendation": "REJECT",
+                "approved": False,
+                "rejection_reason": reason,
+            },
+            "trade_approved": False,
+            "rejection_reason": reason,
+            "timestamp": datetime.now(),
+        }
+
+    def get_filter_stats(self) -> Dict:
+        """Get filter performance statistics"""
+        return {
+            "min_confidence_threshold": self.min_confidence_threshold,
+            "confluence_required": self.confluence_required,
+            "volatility_threshold": self.volatility_threshold,
+            "trend_strength_min": self.trend_strength_min,
+            "volume_spike_threshold": self.volume_spike_threshold,
+        }
+
+
+if __name__ == "__main__":
+    # Test the filter
+    logger = logging.getLogger("HighWinRateFilter")
+    logging.basicConfig(level=logging.INFO)
+
+    filter_system = HighWinRateFilter(logger)
+
+    # Mock data for testing
+    mock_market_data = {
+        "price": 97000,
+        "rsi": 45,
+        "macd": 0.002,
+        "macd_signal": 0.001,
+        "sma_20": 96500,
+        "sma_50": 96000,
+        "adx": 28,
+        "bb_upper": 97500,
+        "bb_lower": 96500,
+        "bb_middle": 97000,
+    }
+
+    # Mock historical data
+    mock_historical = pd.DataFrame(
+        {
+            "close": np.random.normal(97000, 500, 50),
+            "volume": np.random.normal(1000, 200, 50),
+        }
+    )
+
+    result = filter_system.analyze_signal_quality(
+        "BTCUSDT", mock_market_data, mock_historical
+    )
+
+    print("=== HIGH WIN RATE FILTER TEST ===")
+    print(f"Confidence: {result['confidence']:.2%}")
+    print(f"Recommendation: {result['overall_quality']['recommendation']}")
+    print(f"Trade Approved: {result['trade_approved']}")
+    if result.get("rejection_reason"):
+        print(f"Rejection Reason: {result['rejection_reason']}")

--- a/trading/analysis/market_regime_detector.py
+++ b/trading/analysis/market_regime_detector.py
@@ -1,0 +1,525 @@
+"""
+Market Regime Detection for High Win Rate Trading
+Identifies optimal market conditions for trade execution
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+import ta
+from scipy import stats
+from sklearn.cluster import KMeans
+
+
+class MarketRegimeDetector:
+    """
+    Advanced market regime detection system to identify
+    optimal trading conditions for 60%+ win rate
+    """
+
+    def __init__(self, logger: logging.Logger = None):
+        self.logger = logger or logging.getLogger(__name__)
+
+        # Regime classification parameters
+        self.lookback_period = 50
+        self.trend_threshold = 0.02  # 2% minimum for strong trend
+        self.volatility_periods = [10, 20, 50]
+
+        # Trading session definitions (UTC hours)
+        self.trading_sessions = {
+            "asian": {"start": 0, "end": 8, "liquidity": "medium"},
+            "london": {"start": 8, "end": 16, "liquidity": "high"},
+            "new_york": {"start": 13, "end": 21, "liquidity": "high"},
+            "overlap": {"start": 13, "end": 16, "liquidity": "highest"},
+        }
+
+        self.logger.info("📊 Market Regime Detector initialized")
+        self.logger.info(f"   - Lookback period: {self.lookback_period}")
+        self.logger.info(f"   - Trend threshold: {self.trend_threshold*100:.1f}%")
+
+    def detect_current_regime(self, historical_data: pd.DataFrame) -> Dict:
+        """
+        Detect current market regime based on multiple factors
+
+        Returns comprehensive regime analysis for trading decisions
+        """
+        try:
+            if len(historical_data) < self.lookback_period:
+                return self._get_unknown_regime("Insufficient historical data")
+
+            # 1. TREND ANALYSIS
+            trend_analysis = self._analyze_trend(historical_data)
+
+            # 2. VOLATILITY REGIME
+            volatility_regime = self._classify_volatility_regime(historical_data)
+
+            # 3. MOMENTUM ANALYSIS
+            momentum_analysis = self._analyze_momentum(historical_data)
+
+            # 4. MARKET MICROSTRUCTURE
+            microstructure = self._analyze_market_microstructure(historical_data)
+
+            # 5. TRADING SESSION ANALYSIS
+            session_analysis = self._analyze_trading_session()
+
+            # 6. REGIME CLASSIFICATION
+            regime_classification = self._classify_regime(
+                trend_analysis,
+                volatility_regime,
+                momentum_analysis,
+                microstructure,
+                session_analysis,
+            )
+
+            return {
+                "regime": regime_classification,
+                "trend_analysis": trend_analysis,
+                "volatility_regime": volatility_regime,
+                "momentum_analysis": momentum_analysis,
+                "microstructure": microstructure,
+                "session_analysis": session_analysis,
+                "trading_recommendation": self._get_trading_recommendation(
+                    regime_classification
+                ),
+                "timestamp": datetime.now(),
+            }
+
+        except Exception as e:
+            self.logger.error(f"Error in regime detection: {e}")
+            return self._get_unknown_regime(f"Analysis error: {e}")
+
+    def _analyze_trend(self, historical_data: pd.DataFrame) -> Dict:
+        """Comprehensive trend analysis"""
+        try:
+            closes = historical_data["close"].tail(self.lookback_period)
+
+            # Linear regression trend
+            x = np.arange(len(closes))
+            slope, intercept, r_value, p_value, std_err = stats.linregress(x, closes)
+
+            # Normalize slope to percentage
+            avg_price = closes.mean()
+            trend_slope_pct = (slope / avg_price) * 100
+
+            # Moving average trend
+            sma_short = closes.rolling(10).mean().iloc[-1]
+            sma_long = closes.rolling(20).mean().iloc[-1]
+            ma_trend = (sma_short - sma_long) / sma_long * 100
+
+            # ADX calculation for trend strength
+            high = historical_data["high"].tail(self.lookback_period)
+            low = historical_data["low"].tail(self.lookback_period)
+
+            try:
+                adx = ta.trend.ADXIndicator(high, low, closes).adx().iloc[-1]
+            except:
+                adx = 25  # Default neutral value
+
+            # Trend classification
+            if abs(trend_slope_pct) > self.trend_threshold:
+                if trend_slope_pct > 0:
+                    trend_type = "strong_uptrend"
+                    strength = min(abs(trend_slope_pct) / self.trend_threshold, 3.0)
+                else:
+                    trend_type = "strong_downtrend"
+                    strength = min(abs(trend_slope_pct) / self.trend_threshold, 3.0)
+            elif abs(trend_slope_pct) > self.trend_threshold / 2:
+                trend_type = "weak_uptrend" if trend_slope_pct > 0 else "weak_downtrend"
+                strength = abs(trend_slope_pct) / self.trend_threshold
+            else:
+                trend_type = "sideways"
+                strength = 0.5
+
+            return {
+                "type": trend_type,
+                "strength": strength,
+                "slope_pct": trend_slope_pct,
+                "r_squared": r_value**2,
+                "p_value": p_value,
+                "ma_trend_pct": ma_trend,
+                "adx": adx,
+                "favorable_for_trading": strength > 1.0 and adx > 25,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Trend analysis error: {e}")
+            return {"type": "unknown", "strength": 0, "favorable_for_trading": False}
+
+    def _classify_volatility_regime(self, historical_data: pd.DataFrame) -> Dict:
+        """Classify volatility regime"""
+        try:
+            closes = historical_data["close"].tail(self.lookback_period)
+
+            # Calculate returns and volatilities for different periods
+            returns = closes.pct_change().dropna()
+
+            volatilities = {}
+            for period in self.volatility_periods:
+                if len(returns) >= period:
+                    vol = returns.tail(period).std() * np.sqrt(1440)  # Annualized
+                    volatilities[f"vol_{period}"] = vol
+
+            # Current volatility (short-term)
+            current_vol = volatilities.get("vol_10", 0.02)
+
+            # Long-term average volatility
+            long_term_vol = volatilities.get("vol_50", 0.02)
+
+            # Volatility ratio
+            vol_ratio = current_vol / long_term_vol if long_term_vol > 0 else 1.0
+
+            # Classify volatility regime
+            if current_vol < 0.015:  # Very low volatility
+                vol_regime = "low"
+                trading_favorable = True
+            elif current_vol < 0.03:  # Normal volatility
+                vol_regime = "normal"
+                trading_favorable = True
+            elif current_vol < 0.05:  # High volatility
+                vol_regime = "high"
+                trading_favorable = False
+            else:  # Extreme volatility
+                vol_regime = "extreme"
+                trading_favorable = False
+
+            return {
+                "regime": vol_regime,
+                "current_vol": current_vol,
+                "long_term_vol": long_term_vol,
+                "vol_ratio": vol_ratio,
+                "volatilities": volatilities,
+                "trading_favorable": trading_favorable,
+                "vol_expanding": vol_ratio > 1.2,
+                "vol_contracting": vol_ratio < 0.8,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Volatility regime error: {e}")
+            return {"regime": "unknown", "trading_favorable": False}
+
+    def _analyze_momentum(self, historical_data: pd.DataFrame) -> Dict:
+        """Analyze momentum indicators"""
+        try:
+            closes = historical_data["close"].tail(self.lookback_period)
+
+            # RSI
+            try:
+                rsi = ta.momentum.RSIIndicator(closes).rsi().iloc[-1]
+            except:
+                rsi = 50
+
+            # MACD
+            try:
+                macd_indicator = ta.trend.MACD(closes)
+                macd = macd_indicator.macd().iloc[-1]
+                macd_signal = macd_indicator.macd_signal().iloc[-1]
+                macd_histogram = macd_indicator.macd_diff().iloc[-1]
+            except:
+                macd = macd_signal = macd_histogram = 0
+
+            # Momentum classification
+            momentum_signals = []
+
+            # RSI momentum
+            if 40 < rsi < 60:
+                momentum_signals.append("neutral")
+            elif 30 < rsi < 70:
+                momentum_signals.append("healthy")
+            else:
+                momentum_signals.append("extreme")
+
+            # MACD momentum
+            if abs(macd_histogram) > 0.001:
+                momentum_signals.append("strong")
+            else:
+                momentum_signals.append("weak")
+
+            # Overall momentum assessment
+            if "healthy" in momentum_signals and "strong" in momentum_signals:
+                momentum_quality = "excellent"
+                momentum_score = 1.0
+            elif "healthy" in momentum_signals or "strong" in momentum_signals:
+                momentum_quality = "good"
+                momentum_score = 0.7
+            elif "neutral" in momentum_signals:
+                momentum_quality = "neutral"
+                momentum_score = 0.5
+            else:
+                momentum_quality = "poor"
+                momentum_score = 0.2
+
+            return {
+                "quality": momentum_quality,
+                "score": momentum_score,
+                "rsi": rsi,
+                "macd": macd,
+                "macd_signal": macd_signal,
+                "macd_histogram": macd_histogram,
+                "signals": momentum_signals,
+                "trading_favorable": momentum_score >= 0.7,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Momentum analysis error: {e}")
+            return {"quality": "unknown", "score": 0.5, "trading_favorable": False}
+
+    def _analyze_market_microstructure(self, historical_data: pd.DataFrame) -> Dict:
+        """Analyze market microstructure indicators"""
+        try:
+            if "volume" not in historical_data.columns:
+                return {"liquidity": "unknown", "trading_favorable": False}
+
+            volumes = historical_data["volume"].tail(20)
+            closes = historical_data["close"].tail(20)
+
+            # Volume analysis
+            avg_volume = volumes.mean()
+            recent_volume = volumes.tail(5).mean()
+            volume_ratio = recent_volume / avg_volume if avg_volume > 0 else 1.0
+
+            # Price-volume relationship
+            price_changes = closes.pct_change().tail(10)
+            volume_changes = volumes.pct_change().tail(10)
+
+            # Correlation between price and volume changes
+            try:
+                pv_correlation = np.corrcoef(
+                    price_changes.dropna(), volume_changes.dropna()
+                )[0, 1]
+                if np.isnan(pv_correlation):
+                    pv_correlation = 0
+            except:
+                pv_correlation = 0
+
+            # Liquidity assessment
+            if volume_ratio > 1.5:
+                liquidity = "high"
+                liquidity_score = 1.0
+            elif volume_ratio > 1.0:
+                liquidity = "normal"
+                liquidity_score = 0.7
+            elif volume_ratio > 0.5:
+                liquidity = "low"
+                liquidity_score = 0.4
+            else:
+                liquidity = "very_low"
+                liquidity_score = 0.2
+
+            return {
+                "liquidity": liquidity,
+                "liquidity_score": liquidity_score,
+                "volume_ratio": volume_ratio,
+                "pv_correlation": pv_correlation,
+                "avg_volume": avg_volume,
+                "recent_volume": recent_volume,
+                "trading_favorable": liquidity_score >= 0.7,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Microstructure analysis error: {e}")
+            return {"liquidity": "unknown", "trading_favorable": False}
+
+    def _analyze_trading_session(self) -> Dict:
+        """Analyze current trading session"""
+        try:
+            current_hour = datetime.utcnow().hour
+
+            # Determine active sessions
+            active_sessions = []
+            for session_name, session_info in self.trading_sessions.items():
+                if session_name == "overlap":
+                    continue  # Handle overlap separately
+
+                start_hour = session_info["start"]
+                end_hour = session_info["end"]
+
+                if start_hour <= current_hour < end_hour:
+                    active_sessions.append(session_name)
+
+            # Check for overlap session
+            if (
+                self.trading_sessions["overlap"]["start"]
+                <= current_hour
+                < self.trading_sessions["overlap"]["end"]
+            ):
+                active_sessions.append("overlap")
+
+            # Determine session quality
+            if "overlap" in active_sessions:
+                session_quality = "excellent"
+                liquidity_level = "highest"
+                session_score = 1.0
+            elif any(session in active_sessions for session in ["london", "new_york"]):
+                session_quality = "good"
+                liquidity_level = "high"
+                session_score = 0.8
+            elif "asian" in active_sessions:
+                session_quality = "moderate"
+                liquidity_level = "medium"
+                session_score = 0.6
+            else:
+                session_quality = "poor"
+                liquidity_level = "low"
+                session_score = 0.3
+
+            return {
+                "active_sessions": active_sessions,
+                "quality": session_quality,
+                "liquidity_level": liquidity_level,
+                "score": session_score,
+                "current_hour_utc": current_hour,
+                "trading_favorable": session_score >= 0.6,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Trading session analysis error: {e}")
+            return {"quality": "unknown", "trading_favorable": False}
+
+    def _classify_regime(
+        self,
+        trend_analysis: Dict,
+        volatility_regime: Dict,
+        momentum_analysis: Dict,
+        microstructure: Dict,
+        session_analysis: Dict,
+    ) -> Dict:
+        """Classify overall market regime"""
+        try:
+            # Calculate regime score
+            factors = [
+                trend_analysis.get("favorable_for_trading", False),
+                volatility_regime.get("trading_favorable", False),
+                momentum_analysis.get("trading_favorable", False),
+                microstructure.get("trading_favorable", False),
+                session_analysis.get("trading_favorable", False),
+            ]
+
+            favorable_factors = sum(factors)
+            regime_score = favorable_factors / len(factors)
+
+            # Classify regime
+            if regime_score >= 0.8:
+                regime_class = "optimal"
+                trade_recommendation = "aggressive"
+            elif regime_score >= 0.6:
+                regime_class = "favorable"
+                trade_recommendation = "normal"
+            elif regime_score >= 0.4:
+                regime_class = "neutral"
+                trade_recommendation = "conservative"
+            else:
+                regime_class = "unfavorable"
+                trade_recommendation = "avoid"
+
+            # Special conditions
+            if volatility_regime.get("regime") == "extreme":
+                regime_class = "unfavorable"
+                trade_recommendation = "avoid"
+
+            if trend_analysis.get("type") == "sideways" and regime_score < 0.7:
+                trade_recommendation = "avoid"
+
+            return {
+                "class": regime_class,
+                "score": regime_score,
+                "favorable_factors": favorable_factors,
+                "total_factors": len(factors),
+                "trade_recommendation": trade_recommendation,
+                "should_trade": regime_score >= 0.6,
+                "confidence": regime_score,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Regime classification error: {e}")
+            return {
+                "class": "unknown",
+                "score": 0,
+                "trade_recommendation": "avoid",
+                "should_trade": False,
+            }
+
+    def _get_trading_recommendation(self, regime_classification: Dict) -> Dict:
+        """Get specific trading recommendations based on regime"""
+        recommendation = regime_classification.get("trade_recommendation", "avoid")
+
+        if recommendation == "aggressive":
+            return {
+                "action": "trade_aggressively",
+                "position_size_multiplier": 1.5,
+                "max_concurrent_trades": 3,
+                "confidence_threshold": 0.70,
+                "message": "Optimal conditions for aggressive trading",
+            }
+        elif recommendation == "normal":
+            return {
+                "action": "trade_normally",
+                "position_size_multiplier": 1.0,
+                "max_concurrent_trades": 2,
+                "confidence_threshold": 0.75,
+                "message": "Favorable conditions for normal trading",
+            }
+        elif recommendation == "conservative":
+            return {
+                "action": "trade_conservatively",
+                "position_size_multiplier": 0.5,
+                "max_concurrent_trades": 1,
+                "confidence_threshold": 0.85,
+                "message": "Neutral conditions - trade conservatively",
+            }
+        else:
+            return {
+                "action": "avoid_trading",
+                "position_size_multiplier": 0,
+                "max_concurrent_trades": 0,
+                "confidence_threshold": 0.95,
+                "message": "Unfavorable conditions - avoid trading",
+            }
+
+    def _get_unknown_regime(self, reason: str) -> Dict:
+        """Return unknown regime with safe defaults"""
+        return {
+            "regime": {
+                "class": "unknown",
+                "score": 0,
+                "trade_recommendation": "avoid",
+                "should_trade": False,
+            },
+            "trading_recommendation": {
+                "action": "avoid_trading",
+                "message": f"Unknown regime: {reason}",
+            },
+            "timestamp": datetime.now(),
+        }
+
+
+if __name__ == "__main__":
+    # Test the regime detector
+    logger = logging.getLogger("MarketRegimeDetector")
+    logging.basicConfig(level=logging.INFO)
+
+    detector = MarketRegimeDetector(logger)
+
+    # Mock historical data
+    np.random.seed(42)
+    dates = pd.date_range("2024-01-01", periods=100, freq="1min")
+    mock_data = pd.DataFrame(
+        {
+            "close": np.cumsum(np.random.randn(100) * 0.01) + 97000,
+            "high": np.cumsum(np.random.randn(100) * 0.01) + 97050,
+            "low": np.cumsum(np.random.randn(100) * 0.01) + 96950,
+            "volume": np.random.lognormal(10, 0.5, 100),
+        },
+        index=dates,
+    )
+
+    result = detector.detect_current_regime(mock_data)
+
+    print("=== MARKET REGIME DETECTION TEST ===")
+    print(f"Regime Class: {result['regime']['class']}")
+    print(f"Regime Score: {result['regime']['score']:.2%}")
+    print(f"Should Trade: {result['regime']['should_trade']}")
+    print(f"Recommendation: {result['trading_recommendation']['action']}")
+    print(f"Message: {result['trading_recommendation']['message']}")

--- a/trading/cooldown/trade_cooldown_manager.py
+++ b/trading/cooldown/trade_cooldown_manager.py
@@ -1,0 +1,352 @@
+"""
+Trade Cooldown Manager for Fewer, Bigger Trades Strategy
+Prevents overtrading and ensures quality trade selection
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class TradeRecord:
+    """Record of a completed trade for cooldown tracking"""
+
+    symbol: str
+    timestamp: datetime
+    side: str
+    size: float
+    confidence: float
+    pnl: Optional[float] = None
+
+
+class TradeCooldownManager:
+    """
+    Manages trade cooldowns to implement fewer, bigger trades strategy
+    """
+
+    def __init__(self, logger: logging.Logger = None, cooldown_minutes: int = 15):
+        self.logger = logger or logging.getLogger(__name__)
+        self.cooldown_minutes = cooldown_minutes
+        self.cooldown_seconds = cooldown_minutes * 60
+
+        # Trade tracking
+        self.recent_trades: List[TradeRecord] = []
+        self.last_trade_time: Dict[str, datetime] = {}
+        self.daily_trade_count = 0
+        self.last_reset_date = datetime.now().date()
+
+        # Persistence file
+        self.state_file = Path.home() / ".elvis" / "trade_cooldown_state.json"
+        self.state_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Load previous state
+        self._load_state()
+
+        self.logger.info(f"🕐 Trade Cooldown Manager initialized")
+        self.logger.info(f"   - Cooldown period: {cooldown_minutes} minutes")
+        self.logger.info(f"   - Strategy: FEWER, BIGGER trades")
+
+    def can_trade(self, symbol: str, max_daily_trades: int = 8) -> Dict[str, any]:
+        """
+        Check if trading is allowed based on cooldown rules
+
+        Args:
+            symbol: Trading symbol
+            max_daily_trades: Maximum trades per day
+
+        Returns:
+            Dict with trade permission and details
+        """
+        try:
+            self._check_daily_reset()
+
+            # Check daily trade limit
+            if self.daily_trade_count >= max_daily_trades:
+                return {
+                    "can_trade": False,
+                    "reason": f"Daily trade limit reached ({self.daily_trade_count}/{max_daily_trades})",
+                    "cooldown_remaining": None,
+                    "next_trade_time": None,
+                }
+
+            # Check symbol-specific cooldown
+            if symbol in self.last_trade_time:
+                last_trade = self.last_trade_time[symbol]
+                time_since_last = (datetime.now() - last_trade).total_seconds()
+
+                if time_since_last < self.cooldown_seconds:
+                    remaining_cooldown = self.cooldown_seconds - time_since_last
+                    next_trade_time = datetime.now() + timedelta(
+                        seconds=remaining_cooldown
+                    )
+
+                    return {
+                        "can_trade": False,
+                        "reason": f"Symbol {symbol} in cooldown",
+                        "cooldown_remaining": remaining_cooldown,
+                        "next_trade_time": next_trade_time,
+                        "minutes_remaining": remaining_cooldown / 60,
+                    }
+
+            # Check global cooldown (any symbol)
+            if self.recent_trades:
+                last_any_trade = max(
+                    trade.timestamp for trade in self.recent_trades[-10:]
+                )
+                global_cooldown = 300  # 5 minutes minimum between any trades
+                time_since_any = (datetime.now() - last_any_trade).total_seconds()
+
+                if time_since_any < global_cooldown:
+                    remaining = global_cooldown - time_since_any
+                    return {
+                        "can_trade": False,
+                        "reason": "Global trade cooldown active",
+                        "cooldown_remaining": remaining,
+                        "next_trade_time": datetime.now()
+                        + timedelta(seconds=remaining),
+                        "minutes_remaining": remaining / 60,
+                    }
+
+            # Trading allowed
+            return {
+                "can_trade": True,
+                "reason": "No cooldown restrictions",
+                "daily_trades_remaining": max_daily_trades - self.daily_trade_count,
+                "cooldown_remaining": 0,
+            }
+
+        except Exception as e:
+            self.logger.error(f"Error checking trade permission: {e}")
+            return {
+                "can_trade": False,
+                "reason": f"Cooldown check error: {e}",
+                "cooldown_remaining": None,
+            }
+
+    def record_trade(
+        self,
+        symbol: str,
+        side: str,
+        size: float,
+        confidence: float,
+        pnl: Optional[float] = None,
+    ):
+        """
+        Record a completed trade for cooldown tracking
+
+        Args:
+            symbol: Trading symbol
+            side: 'BUY' or 'SELL'
+            size: Position size
+            confidence: Signal confidence
+            pnl: Profit/loss if available
+        """
+        try:
+            self._check_daily_reset()
+
+            # Create trade record
+            trade_record = TradeRecord(
+                symbol=symbol,
+                timestamp=datetime.now(),
+                side=side,
+                size=size,
+                confidence=confidence,
+                pnl=pnl,
+            )
+
+            # Add to recent trades (keep last 50)
+            self.recent_trades.append(trade_record)
+            if len(self.recent_trades) > 50:
+                self.recent_trades = self.recent_trades[-50:]
+
+            # Update symbol-specific cooldown
+            self.last_trade_time[symbol] = datetime.now()
+
+            # Increment daily counter
+            self.daily_trade_count += 1
+
+            # Save state
+            self._save_state()
+
+            self.logger.info(
+                f"📝 Trade recorded: {symbol} {side} | Daily count: {self.daily_trade_count}"
+            )
+            self.logger.info(
+                f"   Next {symbol} trade available in {self.cooldown_minutes} minutes"
+            )
+
+        except Exception as e:
+            self.logger.error(f"Error recording trade: {e}")
+
+    def get_cooldown_status(self) -> Dict[str, any]:
+        """Get current cooldown status for all symbols"""
+        try:
+            self._check_daily_reset()
+
+            status = {
+                "daily_trade_count": self.daily_trade_count,
+                "last_reset_date": self.last_reset_date.isoformat(),
+                "symbol_cooldowns": {},
+                "recent_trades_count": len(self.recent_trades),
+                "cooldown_minutes": self.cooldown_minutes,
+            }
+
+            # Check each symbol's cooldown
+            for symbol, last_time in self.last_trade_time.items():
+                time_since = (datetime.now() - last_time).total_seconds()
+                remaining = max(0, self.cooldown_seconds - time_since)
+
+                status["symbol_cooldowns"][symbol] = {
+                    "last_trade": last_time.isoformat(),
+                    "cooldown_remaining_seconds": remaining,
+                    "cooldown_remaining_minutes": remaining / 60,
+                    "can_trade": remaining == 0,
+                }
+
+            return status
+
+        except Exception as e:
+            self.logger.error(f"Error getting cooldown status: {e}")
+            return {"error": str(e)}
+
+    def force_reset_cooldown(self, symbol: Optional[str] = None):
+        """
+        Force reset cooldown for testing or emergency trading
+
+        Args:
+            symbol: Specific symbol to reset, or None for all
+        """
+        try:
+            if symbol:
+                if symbol in self.last_trade_time:
+                    del self.last_trade_time[symbol]
+                    self.logger.warning(f"⚠️ FORCED cooldown reset for {symbol}")
+            else:
+                self.last_trade_time.clear()
+                self.recent_trades.clear()
+                self.daily_trade_count = 0
+                self.logger.warning("⚠️ FORCED cooldown reset for ALL symbols")
+
+            self._save_state()
+
+        except Exception as e:
+            self.logger.error(f"Error resetting cooldown: {e}")
+
+    def _check_daily_reset(self):
+        """Check if we need to reset daily counters"""
+        current_date = datetime.now().date()
+        if current_date > self.last_reset_date:
+            self.daily_trade_count = 0
+            self.last_reset_date = current_date
+
+            # Clean old symbol cooldowns (older than 24 hours)
+            cutoff_time = datetime.now() - timedelta(hours=24)
+            symbols_to_remove = [
+                symbol
+                for symbol, last_time in self.last_trade_time.items()
+                if last_time < cutoff_time
+            ]
+            for symbol in symbols_to_remove:
+                del self.last_trade_time[symbol]
+
+            self.logger.info(f"🔄 Daily trade counters reset: {current_date}")
+            self._save_state()
+
+    def _save_state(self):
+        """Save cooldown state to file"""
+        try:
+            state = {
+                "daily_trade_count": self.daily_trade_count,
+                "last_reset_date": self.last_reset_date.isoformat(),
+                "last_trade_time": {
+                    symbol: time.isoformat()
+                    for symbol, time in self.last_trade_time.items()
+                },
+                "recent_trades": [
+                    {
+                        "symbol": trade.symbol,
+                        "timestamp": trade.timestamp.isoformat(),
+                        "side": trade.side,
+                        "size": trade.size,
+                        "confidence": trade.confidence,
+                        "pnl": trade.pnl,
+                    }
+                    for trade in self.recent_trades[-20:]  # Save last 20 trades
+                ],
+            }
+
+            with open(self.state_file, "w") as f:
+                json.dump(state, f, indent=2)
+
+        except Exception as e:
+            self.logger.warning(f"Failed to save cooldown state: {e}")
+
+    def _load_state(self):
+        """Load cooldown state from file"""
+        try:
+            if self.state_file.exists():
+                with open(self.state_file, "r") as f:
+                    state = json.load(f)
+
+                self.daily_trade_count = state.get("daily_trade_count", 0)
+
+                # Load last reset date
+                reset_date_str = state.get("last_reset_date")
+                if reset_date_str:
+                    self.last_reset_date = datetime.fromisoformat(reset_date_str).date()
+
+                # Load last trade times
+                last_trade_times = state.get("last_trade_time", {})
+                for symbol, time_str in last_trade_times.items():
+                    self.last_trade_time[symbol] = datetime.fromisoformat(time_str)
+
+                # Load recent trades
+                recent_trades_data = state.get("recent_trades", [])
+                self.recent_trades = [
+                    TradeRecord(
+                        symbol=trade["symbol"],
+                        timestamp=datetime.fromisoformat(trade["timestamp"]),
+                        side=trade["side"],
+                        size=trade["size"],
+                        confidence=trade["confidence"],
+                        pnl=trade.get("pnl"),
+                    )
+                    for trade in recent_trades_data
+                ]
+
+                self.logger.info(
+                    f"📁 Loaded cooldown state: {self.daily_trade_count} daily trades"
+                )
+
+        except Exception as e:
+            self.logger.warning(f"Failed to load cooldown state: {e}")
+
+
+if __name__ == "__main__":
+    # Test the cooldown manager
+    logger = logging.getLogger("TradeCooldownManager")
+    logging.basicConfig(level=logging.INFO)
+
+    cooldown_mgr = TradeCooldownManager(logger, cooldown_minutes=15)
+
+    # Test trade permission
+    permission = cooldown_mgr.can_trade("BTCUSDT", max_daily_trades=8)
+    print(f"Can trade BTCUSDT: {permission}")
+
+    # Record a test trade
+    if permission["can_trade"]:
+        cooldown_mgr.record_trade("BTCUSDT", "BUY", 0.001, 0.87, 5.0)
+        print("Trade recorded")
+
+        # Check cooldown after trade
+        new_permission = cooldown_mgr.can_trade("BTCUSDT")
+        print(f"Can trade after recording: {new_permission}")
+
+    # Get status
+    status = cooldown_mgr.get_cooldown_status()
+    print(f"Cooldown status: {status}")

--- a/trading/execution/exits.py
+++ b/trading/execution/exits.py
@@ -1,0 +1,324 @@
+"""
+Exit management utilities: trailing stops and regime-aware take-profit levels.
+
+This module implements two independent exit mechanisms used by the
+profitability roadmap (items #4 and #10):
+
+1. ``TrailingStop`` -- a stateful, per-position trailing stop. For a BUY
+   (long) position it tracks the highest price seen since entry (the
+   "high-water mark") and places the stop a fixed percentage below it, so
+   the stop only ever ratchets upward and locks in profit as the price
+   rises. For a SELL (short) position the logic is mirrored: it tracks the
+   lowest price seen (the "low-water mark") and places the stop a fixed
+   percentage above it.
+
+2. ``dynamic_take_profit`` -- a regime-keyed take-profit price. Trending
+   markets justify wide targets, while ranging/choppy markets call for
+   quick scalps. The take-profit distance is expressed as a *percentage*
+   of the entry price (not an absolute dollar offset, as the original
+   roadmap sketch suggested) so the behaviour stays consistent whether BTC
+   trades at $30k or $120k.
+
+Both utilities are pure stdlib (plus ``math`` for NaN checks): no numpy,
+pandas, torch, or network access is required, so they are safe to import
+in constrained CI environments.
+
+Usage
+-----
+Trailing stop::
+
+    from trading.execution.exits import TrailingStop
+
+    ts = TrailingStop(trail_pct=0.02)  # trail 2% behind the extreme
+    should_close, stop_price = ts.update("pos-1", "BUY", 100.0, 105.0)
+    if should_close:
+        # close the position at market, then forget its state
+        ts.clear("pos-1")
+
+Dynamic take-profit::
+
+    from trading.execution.exits import dynamic_take_profit
+
+    tp_price = dynamic_take_profit("TRENDING", entry_price=50_000.0, side="BUY")
+    # -> 52_500.0  (entry * 1.05 in a trending regime)
+
+Both are defensive: invalid, non-finite, or non-positive prices produce a
+neutral "do nothing" result (no close signal / entry price returned)
+rather than raising, so a bad tick can never crash the trading loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default take-profit distance (as a fraction of entry price) per market
+# regime. Unknown regimes fall back to the conservative RANGING value.
+DEFAULT_REGIME_TP_PCT: Dict[str, float] = {
+    "TRENDING": 0.05,  # ride trends: 5% target
+    "REVERSAL": 0.01,  # reversals resolve quickly: 1% target
+    "RANGING": 0.0025,  # scalp the range: 0.25% target
+    "CHOPPY": 0.001,  # get out fast: 0.1% target
+}
+
+_FALLBACK_REGIME = "RANGING"
+
+
+def _is_valid_price(value: float) -> bool:
+    """Return True if ``value`` is a finite, strictly positive number."""
+    try:
+        return math.isfinite(value) and value > 0
+    except TypeError:
+        return False
+
+
+class TrailingStop:
+    """Stateful per-position trailing stop manager.
+
+    How it works
+    ------------
+    Each position (keyed by ``position_id``) gets its own tracked
+    "extreme" price:
+
+    * BUY (long): the extreme is the *highest* price observed since the
+      position was first seen (seeded with ``max(entry_price,
+      current_price)`` on the first update). The stop sits at
+      ``extreme * (1 - trail_pct)``. Because the extreme can only rise,
+      the stop can only rise -- it never gives back locked-in profit.
+    * SELL (short): mirrored. The extreme is the *lowest* price observed
+      (seeded with ``min(entry_price, current_price)``) and the stop sits
+      at ``extreme * (1 + trail_pct)``, only ever moving down.
+
+    ``update`` returns ``(should_close, stop_price)`` where
+    ``should_close`` is True once the current price crosses the stop
+    (``current <= stop`` for BUY, ``current >= stop`` for SELL).
+
+    How to use it
+    -------------
+    Create one instance per strategy (or per bot) and call
+    :meth:`update` on every tick/candle for each open position. When a
+    position closes -- whether because the stop fired or for any other
+    reason -- call :meth:`clear` so the stale extreme is not reused if
+    the same id is recycled.
+
+    Args:
+        trail_pct: Trailing distance as a fraction of the extreme price
+            (e.g. ``0.02`` trails 2% behind the high/low-water mark).
+            Non-finite or negative values are coerced to the 0.02
+            default with a warning.
+    """
+
+    DEFAULT_TRAIL_PCT = 0.02
+
+    def __init__(self, trail_pct: float = DEFAULT_TRAIL_PCT) -> None:
+        if (
+            not isinstance(trail_pct, (int, float))
+            or not math.isfinite(trail_pct)
+            or trail_pct < 0
+        ):
+            logger.warning(
+                "Invalid trail_pct %r; falling back to default %.4f",
+                trail_pct,
+                self.DEFAULT_TRAIL_PCT,
+            )
+            trail_pct = self.DEFAULT_TRAIL_PCT
+        self.trail_pct: float = float(trail_pct)
+        # position_id -> extreme price (high-water mark for BUY,
+        # low-water mark for SELL).
+        self._extremes: Dict[str, float] = {}
+        # position_id -> normalized side, so a side flip on an existing
+        # id can be detected and handled by re-seeding.
+        self._sides: Dict[str, str] = {}
+
+    def update(
+        self,
+        position_id: str,
+        side: str,
+        entry_price: float,
+        current_price: float,
+    ) -> Tuple[bool, float]:
+        """Advance the trailing stop for one position and check it.
+
+        Args:
+            position_id: Stable identifier of the open position.
+            side: ``"BUY"`` for long positions, ``"SELL"`` for short.
+                Case-insensitive; unknown sides are treated as BUY with
+                a warning.
+            entry_price: The position's entry price. Only used to seed
+                the extreme on the first update for this id.
+            current_price: Latest observed market price.
+
+        Returns:
+            ``(should_close, stop_price)``. ``should_close`` is True when
+            ``current_price`` has crossed the stop. ``stop_price`` is the
+            current stop level. On invalid input the method is a no-op
+            returning ``(False, 0.0)``.
+        """
+        normalized_side = str(side).upper()
+        if normalized_side not in ("BUY", "SELL"):
+            logger.warning(
+                "Unknown side %r for position %s; treating as BUY", side, position_id
+            )
+            normalized_side = "BUY"
+
+        if not _is_valid_price(current_price):
+            logger.warning(
+                "Invalid current_price %r for position %s; skipping update",
+                current_price,
+                position_id,
+            )
+            return (False, 0.0)
+
+        if not _is_valid_price(entry_price):
+            logger.warning(
+                "Invalid entry_price %r for position %s; using current_price as seed",
+                entry_price,
+                position_id,
+            )
+            entry_price = current_price
+
+        key = str(position_id)
+
+        # Re-seed if this is a new position id or the side changed
+        # (a recycled id whose old state would be meaningless).
+        if key not in self._extremes or self._sides.get(key) != normalized_side:
+            if self._sides.get(key) not in (None, normalized_side):
+                logger.info(
+                    "Side changed for position %s (%s -> %s); re-seeding extreme",
+                    key,
+                    self._sides.get(key),
+                    normalized_side,
+                )
+            if normalized_side == "BUY":
+                self._extremes[key] = max(float(entry_price), float(current_price))
+            else:
+                self._extremes[key] = min(float(entry_price), float(current_price))
+            self._sides[key] = normalized_side
+
+        if normalized_side == "BUY":
+            self._extremes[key] = max(self._extremes[key], float(current_price))
+            stop_price = self._extremes[key] * (1.0 - self.trail_pct)
+            should_close = float(current_price) <= stop_price
+        else:
+            self._extremes[key] = min(self._extremes[key], float(current_price))
+            stop_price = self._extremes[key] * (1.0 + self.trail_pct)
+            should_close = float(current_price) >= stop_price
+
+        if should_close:
+            logger.info(
+                "Trailing stop hit for %s position %s: price %.8f crossed stop %.8f",
+                normalized_side,
+                key,
+                float(current_price),
+                stop_price,
+            )
+        return (should_close, stop_price)
+
+    def clear(self, position_id: str) -> None:
+        """Forget the tracked state for a closed position.
+
+        Safe to call with an unknown or already-cleared id (no-op).
+
+        Args:
+            position_id: Identifier previously passed to :meth:`update`.
+        """
+        key = str(position_id)
+        self._extremes.pop(key, None)
+        self._sides.pop(key, None)
+
+
+def dynamic_take_profit(
+    regime: str,
+    entry_price: float,
+    side: str = "BUY",
+    regime_pct: Optional[Dict[str, float]] = None,
+) -> float:
+    """Compute a regime-aware take-profit *price* for a position.
+
+    How it works
+    ------------
+    Each market regime maps to a take-profit distance expressed as a
+    fraction of the entry price (see :data:`DEFAULT_REGIME_TP_PCT`):
+
+    ========== ======= =========================================
+    Regime     Pct     Rationale
+    ========== ======= =========================================
+    TRENDING   0.05    let winners run in a directional market
+    REVERSAL   0.01    capture the snap-back, then get out
+    RANGING    0.0025  scalp inside the range
+    CHOPPY     0.001   minimal target, minimal exposure
+    unknown    0.0025  conservative RANGING fallback
+    ========== ======= =========================================
+
+    The take-profit is then ``entry * (1 + pct)`` for BUY and
+    ``entry * (1 - pct)`` for SELL.
+
+    Note: the original roadmap sketched these targets as absolute dollar
+    offsets. Percentages are used here instead because a fixed dollar
+    offset means completely different risk/reward depending on the asset
+    price level; a percentage keeps the target economically consistent
+    across price regimes and across assets.
+
+    How to use it
+    -------------
+    Call once when a position is opened (or when the detected regime
+    changes) and register the returned price as the take-profit level::
+
+        tp = dynamic_take_profit("CHOPPY", entry_price=100.0, side="SELL")
+        # -> 99.9  (entry * (1 - 0.001))
+
+    Args:
+        regime: Market regime label (e.g. ``"TRENDING"``). Case-
+            insensitive; unknown labels use the RANGING fallback.
+        entry_price: Position entry price. Non-finite or non-positive
+            values are returned unchanged (neutral no-op) with a warning.
+        side: ``"BUY"`` (default) or ``"SELL"``. Case-insensitive;
+            unknown sides are treated as BUY with a warning.
+        regime_pct: Optional override map of ``regime -> pct`` that is
+            merged over the defaults (defaults remain for keys not
+            supplied). Invalid override values are ignored.
+
+    Returns:
+        The take-profit price as a float.
+    """
+    if not _is_valid_price(entry_price):
+        logger.warning(
+            "Invalid entry_price %r for dynamic_take_profit; returning it unchanged",
+            entry_price,
+        )
+        try:
+            return float(entry_price)
+        except (TypeError, ValueError):
+            return 0.0
+
+    pct_map = dict(DEFAULT_REGIME_TP_PCT)
+    if regime_pct:
+        for key, value in regime_pct.items():
+            if isinstance(value, (int, float)) and math.isfinite(value) and value >= 0:
+                pct_map[str(key).upper()] = float(value)
+            else:
+                logger.warning(
+                    "Ignoring invalid take-profit pct %r for regime %r", value, key
+                )
+
+    normalized_regime = str(regime).upper() if regime is not None else ""
+    pct = pct_map.get(normalized_regime)
+    if pct is None:
+        logger.debug(
+            "Unknown regime %r; using %s fallback take-profit pct",
+            regime,
+            _FALLBACK_REGIME,
+        )
+        pct = pct_map.get(_FALLBACK_REGIME, DEFAULT_REGIME_TP_PCT[_FALLBACK_REGIME])
+
+    normalized_side = str(side).upper()
+    if normalized_side not in ("BUY", "SELL"):
+        logger.warning("Unknown side %r for dynamic_take_profit; treating as BUY", side)
+        normalized_side = "BUY"
+
+    if normalized_side == "BUY":
+        return float(entry_price) * (1.0 + pct)
+    return float(entry_price) * (1.0 - pct)

--- a/trading/execution/exits.py
+++ b/trading/execution/exits.py
@@ -148,7 +148,11 @@ class TrailingStop:
                 Case-insensitive; unknown sides are treated as BUY with
                 a warning.
             entry_price: The position's entry price. Only used to seed
-                the extreme on the first update for this id.
+                the extreme on the first update for this id — and again
+                whenever a recycled ``position_id`` flips side (the
+                extreme re-seeds from this call's ``entry_price``), so on
+                a side flip pass the NEW position's entry price, not the
+                old side's.
             current_price: Latest observed market price.
 
         Returns:

--- a/trading/fees/fee_gate.py
+++ b/trading/fees/fee_gate.py
@@ -1,0 +1,245 @@
+"""Fee-aware trade viability gate (roadmap item #5).
+
+How it works
+------------
+Every futures round-trip pays three costs on the *leveraged notional*
+(``entry_price * quantity * leverage``):
+
+1. an entry taker fee  (``notional * taker_fee``),
+2. an exit taker fee   (``notional * taker_fee``),
+3. funding             (``notional * funding_rate * funding_periods``).
+
+:func:`all_in_cost` itemises those costs, and :func:`is_trade_viable`
+compares them against the gross PnL of an expected move so the bot can
+skip trades whose edge is smaller than the fees they would incur.
+
+The default fee constants here deliberately mirror the authoritative
+Binance fee schedule kept in
+``trading/fees/binance_fee_calculator.py`` (``BinanceFeeCalculator``):
+0.04% (0.0004) futures taker fee for a VIP 0 account, and a typical
+0.01% (0.0001) funding rate per 8-hour period. If the schedule changes,
+update ``BinanceFeeCalculator`` first and keep these defaults in sync.
+
+How to use
+----------
+>>> from trading.fees.fee_gate import all_in_cost, is_trade_viable
+>>> all_in_cost(entry_price=50_000.0, quantity=0.01)
+{'entry_fee': 0.2, 'exit_fee': 0.2, 'funding_fee': 0.05, 'total': 0.45}
+>>> viable, net, costs = is_trade_viable(
+...     entry_price=50_000.0, expected_exit_price=50_100.0, quantity=0.01
+... )
+>>> viable, round(net, 8)
+(True, 0.55)
+
+Both functions are defensive: any non-finite (NaN/inf) or non-positive
+price/quantity input yields a neutral result (zero costs, trade flagged
+as not viable) instead of raising, so callers in the live loop never
+crash on bad ticker data.
+
+Only the standard library is required; numpy scalars are accepted
+transparently because they coerce cleanly through ``float()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+logger = logging.getLogger(__name__)
+
+#: Binance USD-M futures taker fee (VIP 0). Mirrors
+#: ``BinanceFeeCalculator.futures_taker_fee`` in binance_fee_calculator.py.
+DEFAULT_TAKER_FEE: float = 0.0004
+
+#: Typical funding rate per 8-hour funding period. Mirrors the default used
+#: by ``BinanceFeeCalculator.calculate_funding_fee``.
+DEFAULT_FUNDING_RATE: float = 0.0001
+
+_BUY_SIDES = frozenset({"BUY", "LONG"})
+_SELL_SIDES = frozenset({"SELL", "SHORT"})
+
+
+def _zero_costs() -> dict[str, float]:
+    """Return an all-zero cost breakdown (neutral no-op result)."""
+    return {"entry_fee": 0.0, "exit_fee": 0.0, "funding_fee": 0.0, "total": 0.0}
+
+
+def _is_valid_positive(value: float) -> bool:
+    """True if ``value`` is a finite number strictly greater than zero."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(value) and value > 0.0
+
+
+def all_in_cost(
+    entry_price: float,
+    quantity: float,
+    leverage: float = 1.0,
+    taker_fee: float = DEFAULT_TAKER_FEE,
+    funding_rate: float = DEFAULT_FUNDING_RATE,
+    funding_periods: float = 1,
+) -> dict[str, float]:
+    """Itemise the all-in cost of a leveraged futures round-trip.
+
+    The position notional is ``entry_price * quantity * leverage``.
+    Entry and exit are both assumed to be taker orders (worst case), and
+    funding accrues linearly per funding period held.
+
+    Args:
+        entry_price: Expected entry price (quote currency, e.g. USDT).
+        quantity: Position size in base asset (e.g. BTC).
+        leverage: Leverage multiplier applied to the notional.
+        taker_fee: Taker fee rate per fill (default 0.0004 = 0.04%,
+            the Binance futures VIP 0 rate from
+            ``trading/fees/binance_fee_calculator.py``).
+        funding_rate: Funding rate per funding period (default 0.0001).
+        funding_periods: Number of 8-hour funding periods the position
+            is expected to be held (may be fractional).
+
+    Returns:
+        Dict with ``'entry_fee'``, ``'exit_fee'``, ``'funding_fee'`` and
+        ``'total'`` in quote currency. All zeros if any input is
+        non-finite or if price/quantity/leverage is not strictly
+        positive (neutral no-op — never raises on bad data).
+    """
+    if not (
+        _is_valid_positive(entry_price)
+        and _is_valid_positive(quantity)
+        and _is_valid_positive(leverage)
+    ):
+        logger.warning(
+            "all_in_cost: invalid inputs (entry_price=%r, quantity=%r, "
+            "leverage=%r); returning zero costs",
+            entry_price,
+            quantity,
+            leverage,
+        )
+        return _zero_costs()
+
+    rates = (float(taker_fee), float(funding_rate), float(funding_periods))
+    if not all(math.isfinite(rate) for rate in rates):
+        logger.warning(
+            "all_in_cost: non-finite fee parameters (taker_fee=%r, "
+            "funding_rate=%r, funding_periods=%r); returning zero costs",
+            taker_fee,
+            funding_rate,
+            funding_periods,
+        )
+        return _zero_costs()
+    taker_fee_f, funding_rate_f, funding_periods_f = rates
+
+    notional = float(entry_price) * float(quantity) * float(leverage)
+    entry_fee = notional * taker_fee_f
+    exit_fee = notional * taker_fee_f
+    funding_fee = notional * funding_rate_f * funding_periods_f
+    total = entry_fee + exit_fee + funding_fee
+
+    logger.debug(
+        "all_in_cost: notional=%.8f entry_fee=%.8f exit_fee=%.8f "
+        "funding_fee=%.8f total=%.8f",
+        notional,
+        entry_fee,
+        exit_fee,
+        funding_fee,
+        total,
+    )
+    return {
+        "entry_fee": entry_fee,
+        "exit_fee": exit_fee,
+        "funding_fee": funding_fee,
+        "total": total,
+    }
+
+
+def is_trade_viable(
+    entry_price: float,
+    expected_exit_price: float,
+    quantity: float,
+    side: str = "BUY",
+    leverage: float = 1.0,
+    min_net_profit: float = 0.0,
+    **fee_kw: float,
+) -> tuple[bool, float, dict[str, float]]:
+    """Decide whether an expected move survives fees.
+
+    Gross PnL is ``(exit - entry) * quantity * leverage`` for BUY/LONG
+    and ``(entry - exit) * quantity * leverage`` for SELL/SHORT. The net
+    PnL subtracts the :func:`all_in_cost` total, and the trade is viable
+    only if ``net > min_net_profit`` (strict inequality: a trade that
+    exactly hits the threshold is rejected).
+
+    Args:
+        entry_price: Expected entry price.
+        expected_exit_price: Target/expected exit price.
+        quantity: Position size in base asset.
+        side: ``'BUY'``/``'LONG'`` or ``'SELL'``/``'SHORT'``
+            (case-insensitive).
+        leverage: Leverage multiplier (scales both gross PnL and fees).
+        min_net_profit: Minimum net profit (quote currency) required for
+            the trade to be worth taking.
+        **fee_kw: Passed through to :func:`all_in_cost`
+            (``taker_fee``, ``funding_rate``, ``funding_periods``).
+
+    Returns:
+        ``(viable, net_profit, cost_breakdown)``. On any invalid input
+        (NaN/inf prices, non-positive quantity, unknown side) returns
+        ``(False, 0.0, zero_costs)`` instead of raising.
+
+    Example:
+        >>> viable, net, costs = is_trade_viable(
+        ...     50_000.0, 50_100.0, 0.01, side="BUY", leverage=1.0
+        ... )
+        >>> viable
+        True
+    """
+    side_norm = str(side).upper()
+    if side_norm not in _BUY_SIDES | _SELL_SIDES:
+        logger.warning(
+            "is_trade_viable: unknown side %r; treating trade as not viable",
+            side,
+        )
+        return False, 0.0, _zero_costs()
+
+    exit_valid = _is_valid_positive(expected_exit_price)
+    min_net_valid = math.isfinite(float(min_net_profit))
+    if not (exit_valid and min_net_valid):
+        logger.warning(
+            "is_trade_viable: invalid inputs (expected_exit_price=%r, "
+            "min_net_profit=%r); treating trade as not viable",
+            expected_exit_price,
+            min_net_profit,
+        )
+        return False, 0.0, _zero_costs()
+
+    costs = all_in_cost(entry_price, quantity, leverage=leverage, **fee_kw)
+    if costs["total"] == 0.0 and not (
+        _is_valid_positive(entry_price)
+        and _is_valid_positive(quantity)
+        and _is_valid_positive(leverage)
+    ):
+        # all_in_cost already logged the reason; stay neutral.
+        return False, 0.0, costs
+
+    direction = 1.0 if side_norm in _BUY_SIDES else -1.0
+    gross = (
+        (float(expected_exit_price) - float(entry_price))
+        * float(quantity)
+        * float(leverage)
+        * direction
+    )
+    net = gross - costs["total"]
+    viable = net > float(min_net_profit)
+
+    logger.debug(
+        "is_trade_viable: side=%s gross=%.8f fees=%.8f net=%.8f "
+        "min_net_profit=%.8f -> viable=%s",
+        side_norm,
+        gross,
+        costs["total"],
+        net,
+        min_net_profit,
+        viable,
+    )
+    return viable, net, costs

--- a/trading/optimization/__init__.py
+++ b/trading/optimization/__init__.py
@@ -1,0 +1,2 @@
+"""Parameter-optimization primitives for the profitability roadmap
+(walk-forward grid search with out-of-sample evaluation)."""

--- a/trading/optimization/walk_forward.py
+++ b/trading/optimization/walk_forward.py
@@ -1,0 +1,359 @@
+"""Walk-forward parameter optimization (roadmap item #15).
+
+How it works
+------------
+Classic in-sample grid search overfits: parameters tuned on the whole
+history look great on that same history and fall apart live.  Walk-forward
+optimization guards against this by rolling a train/test window pair
+through the data:
+
+    |----- train (fit params) -----|-- test (out-of-sample) --|
+             |----- train -----------------|-- test --|
+                      ... step forward ...
+
+For every fold the optimizer grid-searches all parameter combinations
+(``itertools.product`` over ``param_grid``) on the *train* slice, picks the
+combination with the best ``metric`` as reported by ``backtest_fn``, then
+re-runs ``backtest_fn`` with that single pick on the *following, unseen
+test slice*.  The distribution of out-of-sample test metrics — not the
+in-sample train metrics — tells you whether the strategy parameters are
+robust.
+
+How to use
+----------
+>>> import pandas as pd
+>>> from trading.optimization.walk_forward import (
+...     WalkForwardOptimizer, sma_crossover_backtest,
+... )
+>>> data = pd.DataFrame({"close": [...]})  # OHLCV or at least a close column
+>>> optimizer = WalkForwardOptimizer(
+...     backtest_fn=sma_crossover_backtest,
+...     param_grid={"sma_short": [5, 10], "sma_long": [20, 50]},
+...     metric="sharpe",
+... )
+>>> report = optimizer.optimize(data, train_window=500, test_window=100)
+>>> report["best_params"]       # pick from the most recent fold
+>>> report["mean_test_metric"]  # average out-of-sample performance
+
+``backtest_fn`` can be any callable ``(data, params) -> dict`` that returns
+a dict of metrics (e.g. ``{"sharpe": 1.2, "total_return": 0.08}``).  A
+combination whose result is missing ``metric`` (or errors out) scores
+``-inf`` and can never be selected over a valid one.
+
+Only stdlib + numpy + pandas are used, so this module is importable in CI
+environments without heavy ML dependencies.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import math
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# Result type of a backtest callable: metric name -> value.
+BacktestFn = Callable[[pd.DataFrame, Dict[str, Any]], Dict[str, float]]
+
+_NEUTRAL_RESULT: Dict[str, float] = {"sharpe": 0.0, "total_return": 0.0}
+
+
+def sma_crossover_backtest(
+    data: pd.DataFrame, params: Dict[str, Any]
+) -> Dict[str, float]:
+    """Vectorized SMA-crossover backtest usable as a ``backtest_fn``.
+
+    Strategy: be long (position = 1) whenever
+    ``SMA(close, params["sma_short"]) > SMA(close, params["sma_long"])``,
+    flat otherwise.  The position is shifted by one bar so the signal
+    computed on bar *t* earns the close-to-close return of bar *t+1*
+    (no look-ahead).
+
+    Metrics returned:
+
+    - ``sharpe``: ``mean(strategy_returns) / std(strategy_returns) *
+      sqrt(len(strategy_returns))``; ``0.0`` when the standard deviation
+      is zero (e.g. never in the market).
+    - ``total_return``: compounded close-to-close strategy return.
+
+    Args:
+        data: DataFrame with a ``close`` column (extra columns ignored).
+        params: dict with integer ``sma_short`` and ``sma_long`` windows.
+
+    Returns:
+        ``{"sharpe": float, "total_return": float}``.  Degenerate input
+        (empty/short data, missing ``close`` column, missing or invalid
+        window params, all-NaN prices) yields the neutral result
+        ``{"sharpe": 0.0, "total_return": 0.0}`` instead of raising.
+    """
+    short_window = params.get("sma_short")
+    long_window = params.get("sma_long")
+    if short_window is None or long_window is None:
+        logger.warning(
+            "sma_crossover_backtest: params must contain 'sma_short' and "
+            "'sma_long' (got %s); returning neutral result",
+            sorted(params),
+        )
+        return dict(_NEUTRAL_RESULT)
+
+    try:
+        short_window = int(short_window)
+        long_window = int(long_window)
+    except (TypeError, ValueError):
+        logger.warning(
+            "sma_crossover_backtest: non-integer SMA windows (%r, %r); "
+            "returning neutral result",
+            params.get("sma_short"),
+            params.get("sma_long"),
+        )
+        return dict(_NEUTRAL_RESULT)
+
+    if short_window < 1 or long_window < 1:
+        logger.warning(
+            "sma_crossover_backtest: SMA windows must be >= 1 (got %d, %d); "
+            "returning neutral result",
+            short_window,
+            long_window,
+        )
+        return dict(_NEUTRAL_RESULT)
+
+    if (
+        not isinstance(data, pd.DataFrame)
+        or "close" not in data.columns
+        or len(data) < 2
+    ):
+        logger.debug(
+            "sma_crossover_backtest: missing 'close' column or fewer than 2 "
+            "rows; returning neutral result"
+        )
+        return dict(_NEUTRAL_RESULT)
+
+    close = pd.to_numeric(data["close"], errors="coerce")
+    if close.notna().sum() < 2:
+        logger.debug(
+            "sma_crossover_backtest: fewer than 2 valid close prices; "
+            "returning neutral result"
+        )
+        return dict(_NEUTRAL_RESULT)
+
+    sma_short = close.rolling(short_window).mean()
+    sma_long = close.rolling(long_window).mean()
+    # Signal on bar t earns the return of bar t+1 (shift avoids look-ahead).
+    position = (sma_short > sma_long).astype(float).shift(1).fillna(0.0)
+
+    # Close-to-close returns, version-proof (no pct_change fill_method).
+    returns = close / close.shift(1) - 1.0
+    returns = returns.replace([np.inf, -np.inf], np.nan).fillna(0.0)
+
+    strategy_returns = position * returns
+    std = float(strategy_returns.std())
+    if not math.isfinite(std) or std == 0.0:
+        sharpe = 0.0
+    else:
+        sharpe = float(strategy_returns.mean() / std * math.sqrt(len(strategy_returns)))
+
+    total_return = float((1.0 + strategy_returns).prod() - 1.0)
+    if not math.isfinite(total_return):
+        total_return = 0.0
+    if not math.isfinite(sharpe):
+        sharpe = 0.0
+
+    return {"sharpe": sharpe, "total_return": total_return}
+
+
+class WalkForwardOptimizer:
+    """Rolling train/test grid search for strategy parameters.
+
+    Args:
+        backtest_fn: callable ``(data, params) -> dict`` returning at least
+            the metric named by ``metric``.  A result missing that metric
+            (or a call that raises) is scored ``-inf`` for that combination.
+        param_grid: mapping of parameter name to the list of candidate
+            values, e.g. ``{"sma_short": [5, 10], "sma_long": [20, 50]}``.
+            The full cartesian product is evaluated on every fold.
+        metric: key of ``backtest_fn``'s result dict to maximize
+            (default ``"sharpe"``).
+
+    Determinism: combinations are generated with ``itertools.product`` in
+    the insertion order of ``param_grid``, and ties keep the earliest
+    combination, so repeated runs on the same data give identical output.
+
+    Example:
+        >>> optimizer = WalkForwardOptimizer(
+        ...     sma_crossover_backtest,
+        ...     {"sma_short": [5, 10], "sma_long": [20, 50]},
+        ... )
+        >>> report = optimizer.optimize(data, train_window=500, test_window=100)
+    """
+
+    def __init__(
+        self,
+        backtest_fn: BacktestFn,
+        param_grid: Dict[str, List[Any]],
+        metric: str = "sharpe",
+    ) -> None:
+        if not callable(backtest_fn):
+            raise TypeError("backtest_fn must be callable")
+        if not param_grid or not isinstance(param_grid, dict):
+            raise ValueError(
+                "param_grid must be a non-empty dict of {name: [values, ...]}"
+            )
+        normalized: Dict[str, List[Any]] = {}
+        for name, values in param_grid.items():
+            values = list(values)
+            if not values:
+                raise ValueError(
+                    f"param_grid[{name!r}] must contain at least one value"
+                )
+            normalized[name] = values
+        self.backtest_fn = backtest_fn
+        self.param_grid = normalized
+        self.metric = metric
+
+    def _param_combinations(self) -> List[Dict[str, Any]]:
+        """All grid combinations, in deterministic itertools.product order."""
+        names = list(self.param_grid)
+        return [
+            dict(zip(names, values))
+            for values in itertools.product(*(self.param_grid[name] for name in names))
+        ]
+
+    def _score(self, data: pd.DataFrame, params: Dict[str, Any]) -> float:
+        """Run ``backtest_fn`` and extract ``self.metric``; ``-inf`` on failure."""
+        try:
+            result = self.backtest_fn(data, params)
+        except Exception:
+            logger.warning(
+                "backtest_fn raised for params %s; scoring -inf", params, exc_info=True
+            )
+            return float("-inf")
+        if not isinstance(result, dict) or self.metric not in result:
+            logger.warning(
+                "backtest_fn result missing metric %r for params %s; scoring -inf",
+                self.metric,
+                params,
+            )
+            return float("-inf")
+        try:
+            value = float(result[self.metric])
+        except (TypeError, ValueError):
+            logger.warning(
+                "backtest_fn metric %r is not numeric (%r) for params %s; scoring -inf",
+                self.metric,
+                result[self.metric],
+                params,
+            )
+            return float("-inf")
+        if math.isnan(value):
+            return float("-inf")
+        return value
+
+    def optimize(
+        self,
+        data: pd.DataFrame,
+        train_window: int,
+        test_window: int,
+        step: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Run the walk-forward optimization over ``data``.
+
+        Args:
+            data: full history, oldest row first.  Slicing is positional
+                (``iloc``), so any index type works.
+            train_window: number of rows in each in-sample training slice.
+            test_window: number of rows in each out-of-sample test slice.
+            step: how many rows to roll forward between folds; defaults to
+                ``test_window`` (adjacent, non-overlapping test slices).
+
+        Returns:
+            dict with:
+
+            - ``"folds"``: list of per-fold dicts with keys
+              ``"train_range"`` (tuple of positional ``(start, end)``,
+              end-exclusive), ``"best_params"``, ``"train_metric"`` and
+              ``"test_metric"``.
+            - ``"best_params"``: best parameters from the **last** fold
+              (the most recent data, i.e. what you would trade next).
+            - ``"mean_test_metric"``: mean of the out-of-sample metrics.
+
+        Raises:
+            ValueError: if the windows are not positive or ``data`` is too
+                short for even one train+test fold.
+        """
+        if step is None:
+            step = test_window
+        if train_window < 1 or test_window < 1 or step < 1:
+            raise ValueError(
+                f"train_window ({train_window}), test_window ({test_window}) and "
+                f"step ({step}) must all be >= 1"
+            )
+        n_rows = 0 if data is None else len(data)
+        min_rows = train_window + test_window
+        if n_rows < min_rows:
+            raise ValueError(
+                f"Not enough data for one walk-forward fold: need at least "
+                f"{min_rows} rows (train_window={train_window} + "
+                f"test_window={test_window}), got {n_rows}"
+            )
+
+        combinations = self._param_combinations()
+        logger.info(
+            "Walk-forward optimization: %d rows, train=%d, test=%d, step=%d, "
+            "%d parameter combinations",
+            n_rows,
+            train_window,
+            test_window,
+            step,
+            len(combinations),
+        )
+
+        folds: List[Dict[str, Any]] = []
+        start = 0
+        while start + train_window + test_window <= n_rows:
+            train_end = start + train_window
+            test_end = train_end + test_window
+            train_slice = data.iloc[start:train_end]
+            test_slice = data.iloc[train_end:test_end]
+
+            # Grid search on the train slice; ties keep the earliest combo
+            # (strict '>') so the search is deterministic.
+            best_params = combinations[0]
+            best_score = self._score(train_slice, best_params)
+            for candidate in combinations[1:]:
+                score = self._score(train_slice, candidate)
+                if score > best_score:
+                    best_score = score
+                    best_params = candidate
+
+            test_score = self._score(test_slice, best_params)
+            folds.append(
+                {
+                    "train_range": (start, train_end),
+                    "best_params": dict(best_params),
+                    "train_metric": best_score,
+                    "test_metric": test_score,
+                }
+            )
+            logger.debug(
+                "Fold %d: train=[%d:%d) best=%s train_%s=%.6g test_%s=%.6g",
+                len(folds),
+                start,
+                train_end,
+                best_params,
+                self.metric,
+                best_score,
+                self.metric,
+                test_score,
+            )
+            start += step
+
+        test_metrics = [fold["test_metric"] for fold in folds]
+        return {
+            "folds": folds,
+            "best_params": dict(folds[-1]["best_params"]),
+            "mean_test_metric": float(np.mean(test_metrics)),
+        }

--- a/trading/risk/position_sizing.py
+++ b/trading/risk/position_sizing.py
@@ -1,0 +1,264 @@
+"""
+Position sizing helpers: volume-based size scaling and Kelly-criterion capital
+allocation (profitability roadmap items #3 and #13).
+
+How it works
+------------
+``volume_multiplier`` measures how active the market currently is by dividing
+the latest volume observation by its rolling mean over ``window`` bars.  A
+value above 1.0 means volume is running hotter than average (conviction behind
+the move), below 1.0 means the market is quiet.  The ratio is clamped to
+``[floor, cap]`` so a single anomalous print can never blow up position size.
+
+``kelly_fraction`` computes the classic Kelly criterion
+
+    f* = (b * p - q) / b
+
+where ``p`` is the win rate, ``q = 1 - p`` and ``b`` is the payoff ratio
+``|avg_win / avg_loss|``.  The raw Kelly output is aggressive, so the result
+is clamped to a conservative ``[floor, cap]`` band (fractional Kelly by
+construction).  ``kelly_from_trades`` derives ``p``, ``avg_win`` and
+``avg_loss`` from a realized trade history and delegates to
+``kelly_fraction``; with fewer than ``min_trades`` samples there is not
+enough statistical evidence, so it stays at ``floor``.
+
+How to use it
+-------------
+::
+
+    from trading.risk.position_sizing import (
+        kelly_fraction,
+        kelly_from_trades,
+        volume_multiplier,
+    )
+
+    # Scale a base position size by current volume activity.
+    size = base_size * volume_multiplier(ohlcv_df)  # ohlcv_df has 'volume'
+
+    # Fraction of equity to risk per trade, from summary stats ...
+    f = kelly_fraction(win_rate=0.55, avg_win=42.0, avg_loss=-30.0)
+
+    # ... or straight from a trade log of {'pnl': float} dicts.
+    f = kelly_from_trades(closed_trades)
+    risk_dollars = equity * f
+
+All functions are defensive: empty/short/NaN inputs return a neutral or floor
+value instead of raising, so callers never need try/except around sizing.
+Only stdlib + numpy + pandas are required.
+"""
+
+import logging
+import math
+from typing import Any, Mapping, Optional, Sequence
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["volume_multiplier", "kelly_fraction", "kelly_from_trades"]
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp ``value`` into ``[lo, hi]`` (``lo`` wins if ``lo > hi``)."""
+    return max(lo, min(hi, value))
+
+
+def volume_multiplier(
+    data: Optional[pd.DataFrame],
+    window: int = 20,
+    floor: float = 0.5,
+    cap: float = 2.0,
+) -> float:
+    """Position-size multiplier based on current vs. average volume.
+
+    Computes ``current_volume / rolling_mean(volume, window)`` where the
+    rolling mean covers the last ``window`` valid observations (including the
+    current bar) and clamps the result to ``[floor, cap]``.
+
+    Args:
+        data: OHLCV DataFrame containing a ``volume`` column (matched
+            case-insensitively, e.g. ``Volume`` also works).
+        window: Number of bars in the rolling mean. Must be >= 1.
+        floor: Lower clamp bound (quiet market -> shrink size).
+        cap: Upper clamp bound (volume spike -> cap the boost).
+
+    Returns:
+        The clamped volume ratio, or ``1.0`` (neutral, no scaling) when the
+        input is missing, has no usable volume column, or has fewer than
+        ``window`` valid volume observations.
+    """
+    neutral = 1.0
+
+    if not isinstance(data, pd.DataFrame) or data.empty:
+        logger.debug("volume_multiplier: missing/empty data -> neutral 1.0")
+        return neutral
+    if window < 1:
+        logger.debug("volume_multiplier: invalid window=%s -> neutral 1.0", window)
+        return neutral
+
+    volume_col = next(
+        (col for col in data.columns if str(col).lower() == "volume"), None
+    )
+    if volume_col is None:
+        logger.debug("volume_multiplier: no volume column -> neutral 1.0")
+        return neutral
+
+    volumes = pd.to_numeric(data[volume_col], errors="coerce")
+    volumes = volumes.replace([np.inf, -np.inf], np.nan).dropna()
+    if len(volumes) < window:
+        logger.debug(
+            "volume_multiplier: %d valid volume rows < window=%d -> neutral 1.0",
+            len(volumes),
+            window,
+        )
+        return neutral
+
+    recent = volumes.iloc[-window:]
+    mean_volume = float(recent.mean())
+    current_volume = float(recent.iloc[-1])
+    if mean_volume <= 0.0 or current_volume < 0.0:
+        logger.debug(
+            "volume_multiplier: degenerate volumes (current=%s, mean=%s) "
+            "-> neutral 1.0",
+            current_volume,
+            mean_volume,
+        )
+        return neutral
+
+    multiplier = _clamp(current_volume / mean_volume, floor, cap)
+    logger.debug(
+        "volume_multiplier: current=%.6g mean=%.6g -> %.4f",
+        current_volume,
+        mean_volume,
+        multiplier,
+    )
+    return multiplier
+
+
+def kelly_fraction(
+    win_rate: float,
+    avg_win: float,
+    avg_loss: float,
+    floor: float = 0.01,
+    cap: float = 0.05,
+) -> float:
+    """Clamped Kelly criterion fraction of capital to risk per trade.
+
+    Uses ``f* = (b * p - q) / b`` with ``p = win_rate``, ``q = 1 - p`` and
+    payoff ratio ``b = |avg_win / avg_loss|``, then clamps to
+    ``[floor, cap]``.
+
+    Args:
+        win_rate: Historical probability of a winning trade, in ``(0, 1)``.
+        avg_win: Average PnL of winning trades (positive).
+        avg_loss: Average PnL of losing trades (typically negative; only its
+            magnitude is used).
+        floor: Minimum fraction returned (also the fallback for degenerate
+            inputs).
+        cap: Maximum fraction returned (fractional-Kelly safety cap).
+
+    Returns:
+        The clamped Kelly fraction. Degenerate inputs -- non-finite values,
+        ``win_rate`` outside ``(0, 1)``, ``avg_loss == 0`` or a non-positive
+        payoff ratio -- return ``floor``.
+    """
+    try:
+        p = float(win_rate)
+        win = float(avg_win)
+        loss = float(avg_loss)
+    except (TypeError, ValueError):
+        logger.debug("kelly_fraction: non-numeric inputs -> floor %.4f", floor)
+        return floor
+
+    if not (math.isfinite(p) and math.isfinite(win) and math.isfinite(loss)):
+        logger.debug("kelly_fraction: non-finite inputs -> floor %.4f", floor)
+        return floor
+    if not 0.0 < p < 1.0:
+        logger.debug("kelly_fraction: win_rate=%s not in (0, 1) -> floor", p)
+        return floor
+    if loss == 0.0:
+        logger.debug("kelly_fraction: avg_loss == 0 -> floor %.4f", floor)
+        return floor
+
+    b = abs(win / loss)
+    if b <= 0.0 or not math.isfinite(b):
+        logger.debug("kelly_fraction: payoff ratio b=%s <= 0 -> floor", b)
+        return floor
+
+    q = 1.0 - p
+    f_star = (b * p - q) / b
+    fraction = _clamp(f_star, floor, cap)
+    logger.debug(
+        "kelly_fraction: p=%.4f b=%.4f f*=%.4f -> %.4f", p, b, f_star, fraction
+    )
+    return fraction
+
+
+def kelly_from_trades(
+    trades: Optional[Sequence[Mapping[str, Any]]],
+    min_trades: int = 20,
+    **kwargs: float,
+) -> float:
+    """Derive a Kelly fraction from a realized trade history.
+
+    Extracts ``pnl`` from each trade dict, computes the win rate and the
+    average winning/losing PnL, and delegates to :func:`kelly_fraction`.
+
+    Args:
+        trades: Sequence of trade records, each a mapping with a numeric
+            ``'pnl'`` key (e.g. ``{'pnl': 12.5}``). Records with a missing or
+            non-numeric ``pnl`` are ignored. Zero-PnL trades count toward the
+            sample size but are neither wins nor losses.
+        min_trades: Minimum number of valid trades required before the
+            statistics are trusted.
+        **kwargs: Forwarded to :func:`kelly_fraction` (``floor``, ``cap``).
+
+    Returns:
+        The clamped Kelly fraction, or ``floor`` when there are fewer than
+        ``min_trades`` valid trades or the history has no wins or no losses
+        (not enough evidence to size above the minimum).
+    """
+    floor = float(kwargs.get("floor", 0.01))
+
+    pnls: list[float] = []
+    for trade in trades or ():
+        try:
+            pnl = float(trade["pnl"])
+        except (TypeError, KeyError, ValueError):
+            continue
+        if math.isfinite(pnl):
+            pnls.append(pnl)
+
+    if len(pnls) < min_trades:
+        logger.debug(
+            "kelly_from_trades: %d valid trades < min_trades=%d -> floor %.4f",
+            len(pnls),
+            min_trades,
+            floor,
+        )
+        return floor
+
+    wins = [pnl for pnl in pnls if pnl > 0.0]
+    losses = [pnl for pnl in pnls if pnl < 0.0]
+    if not wins or not losses:
+        logger.debug(
+            "kelly_from_trades: one-sided history (%d wins, %d losses) "
+            "-> floor %.4f",
+            len(wins),
+            len(losses),
+            floor,
+        )
+        return floor
+
+    win_rate = len(wins) / len(pnls)
+    avg_win = sum(wins) / len(wins)
+    avg_loss = sum(losses) / len(losses)
+    logger.debug(
+        "kelly_from_trades: n=%d win_rate=%.4f avg_win=%.4f avg_loss=%.4f",
+        len(pnls),
+        win_rate,
+        avg_win,
+        avg_loss,
+    )
+    return kelly_fraction(win_rate, avg_win, avg_loss, **kwargs)

--- a/trading/signals/__init__.py
+++ b/trading/signals/__init__.py
@@ -1,0 +1,2 @@
+"""Signal-quality primitives for the profitability roadmap (filters, order
+flow, multi-timeframe alignment, adaptive ensemble weighting)."""

--- a/trading/signals/adaptive_ensemble.py
+++ b/trading/signals/adaptive_ensemble.py
@@ -1,0 +1,295 @@
+"""Accuracy-weighted adaptive ensemble aggregation (roadmap item #11).
+
+How it works
+------------
+Each model in the ensemble carries a rolling accuracy score in ``[0, 1]``.
+Scores are updated with an exponential moving average (EMA) so that recent
+performance dominates while older performance decays::
+
+    new_accuracy = ema_alpha * observed_accuracy + (1 - ema_alpha) * old_accuracy
+
+The per-model *weights* are simply the accuracies normalized to sum to 1.
+When aggregating a set of predictions, only the models present in BOTH the
+weight table and the prediction dict contribute, and their weights are
+re-normalized over that subset so the output stays on the same scale as the
+inputs regardless of which models reported.
+
+State can optionally be persisted to a JSON file (atomic write via a
+temporary file + ``os.replace``) so weights survive process restarts.
+Loading tolerates a missing or corrupt file by falling back to the initial
+accuracies — the ensemble is always usable.
+
+How to use it
+-------------
+>>> weights = AdaptiveEnsembleWeights(
+...     {"lstm": 0.55, "rf": 0.60, "xgb": 0.50},
+...     ema_alpha=0.7,
+...     state_path="state/ensemble_weights.json",  # optional persistence
+... )
+>>> signal = weights.weighted_signal({"lstm": 1.0, "rf": -1.0, "xgb": 0.0})
+>>> weights.update("lstm", accuracy=0.72)  # after evaluating a prediction
+>>> weights.save()  # no-op when state_path is None
+
+All entry points degrade gracefully: NaN/inf accuracies or predictions are
+ignored (with a warning), empty inputs yield a neutral ``0.0`` signal, and
+no method raises on bad runtime data.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AdaptiveEnsembleWeights"]
+
+
+class AdaptiveEnsembleWeights:
+    """Maintain EMA-updated per-model accuracies and aggregate predictions.
+
+    Args:
+        initial_accuracies: Mapping of model name to starting accuracy.
+            Values are clamped to ``[0, 1]``; non-finite values become 0.0.
+        ema_alpha: EMA smoothing factor in ``[0, 1]``. Higher values react
+            faster to new accuracy observations. Out-of-range values are
+            clamped (with a warning).
+        state_path: Optional JSON file used by :meth:`save`/:meth:`load`.
+            When provided, existing state is loaded immediately; a missing
+            or corrupt file silently falls back to ``initial_accuracies``.
+    """
+
+    def __init__(
+        self,
+        initial_accuracies: dict[str, float],
+        ema_alpha: float = 0.7,
+        state_path: str | None = None,
+    ) -> None:
+        self._initial: dict[str, float] = {
+            str(name): self._sanitize_accuracy(value, model=str(name))
+            for name, value in dict(initial_accuracies or {}).items()
+        }
+        if not 0.0 <= ema_alpha <= 1.0 or not math.isfinite(ema_alpha):
+            clamped = min(max(ema_alpha, 0.0), 1.0)
+            clamped = clamped if math.isfinite(clamped) else 0.7
+            logger.warning(
+                "ema_alpha=%r outside [0, 1]; clamped to %.3f", ema_alpha, clamped
+            )
+            ema_alpha = clamped
+        self._ema_alpha = float(ema_alpha)
+        self._state_path = state_path
+        self._accuracies: dict[str, float] = dict(self._initial)
+        if state_path is not None:
+            self.load()
+
+    # ------------------------------------------------------------------
+    # Weights
+    # ------------------------------------------------------------------
+    @property
+    def accuracies(self) -> dict[str, float]:
+        """Current (unnormalized) per-model accuracy scores."""
+        return dict(self._accuracies)
+
+    @property
+    def weights(self) -> dict[str, float]:
+        """Accuracies normalized to sum to 1.
+
+        Returns a uniform distribution when every accuracy is zero, and an
+        empty dict when no models are tracked.
+        """
+        if not self._accuracies:
+            return {}
+        total = sum(self._accuracies.values())
+        if total <= 0.0:
+            uniform = 1.0 / len(self._accuracies)
+            return {model: uniform for model in self._accuracies}
+        return {model: acc / total for model, acc in self._accuracies.items()}
+
+    # ------------------------------------------------------------------
+    # Updates
+    # ------------------------------------------------------------------
+    def update(self, model: str, accuracy: float) -> None:
+        """EMA-update a model's accuracy; unknown models are added.
+
+        ``new = ema_alpha * accuracy + (1 - ema_alpha) * old``. A model not
+        yet tracked is inserted with the observed accuracy directly.
+        Non-finite accuracies are ignored with a warning (no-op).
+        """
+        try:
+            observed = float(accuracy)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring non-numeric accuracy %r for %s", accuracy, model)
+            return
+        if not math.isfinite(observed):
+            logger.warning("Ignoring non-finite accuracy %r for %s", accuracy, model)
+            return
+        observed = self._sanitize_accuracy(observed, model=model)
+        old = self._accuracies.get(model)
+        if old is None:
+            self._accuracies[model] = observed
+            logger.info("Added ensemble model %s with accuracy %.4f", model, observed)
+            return
+        self._accuracies[model] = (
+            self._ema_alpha * observed + (1.0 - self._ema_alpha) * old
+        )
+        logger.debug(
+            "EMA update %s: observed=%.4f old=%.4f new=%.4f",
+            model,
+            observed,
+            old,
+            self._accuracies[model],
+        )
+
+    # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+    def weighted_signal(self, predictions: dict[str, float]) -> float:
+        """Weight-average predictions over models known to the ensemble.
+
+        Only models present in BOTH :attr:`weights` and ``predictions``
+        contribute; weights are re-normalized over that subset. Non-finite
+        predictions are skipped. Returns ``0.0`` (neutral) when the
+        intersection is empty.
+        """
+        if not predictions:
+            return 0.0
+        weights = self.weights
+        usable: dict[str, float] = {}
+        for model, value in predictions.items():
+            if model not in weights:
+                continue
+            try:
+                pred = float(value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Skipping non-numeric prediction %r for %s", value, model
+                )
+                continue
+            if not math.isfinite(pred):
+                logger.warning("Skipping non-finite prediction %r for %s", value, model)
+                continue
+            usable[model] = pred
+        if not usable:
+            return 0.0
+        subset_total = sum(weights[model] for model in usable)
+        if subset_total <= 0.0:
+            # Every overlapping weight is zero: fall back to a plain mean.
+            return float(sum(usable.values()) / len(usable))
+        return float(
+            sum(weights[model] * pred for model, pred in usable.items()) / subset_total
+        )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        """Atomically persist accuracies to ``state_path`` as JSON.
+
+        No-op (with a debug log) when ``state_path`` is None. The write goes
+        to a temporary file in the destination directory followed by
+        ``os.replace`` so readers never observe a partial file.
+        """
+        if self._state_path is None:
+            logger.debug("save() skipped: no state_path configured")
+            return
+        payload = {"ema_alpha": self._ema_alpha, "accuracies": self._accuracies}
+        directory = os.path.dirname(os.path.abspath(self._state_path))
+        try:
+            os.makedirs(directory, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(
+                prefix=".ensemble_weights_", suffix=".json.tmp", dir=directory
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, indent=2, sort_keys=True)
+                os.replace(tmp_path, self._state_path)
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except OSError as exc:
+            logger.error(
+                "Failed to save ensemble state to %s: %s", self._state_path, exc
+            )
+            return
+        logger.debug("Saved ensemble state to %s", self._state_path)
+
+    def load(self) -> bool:
+        """Load accuracies from ``state_path``, merging over the initials.
+
+        Models present in the file override their initial accuracy; models
+        only present in the initials are kept (so newly added models are not
+        lost when older state is loaded). A missing, unreadable, or corrupt
+        file leaves the initial accuracies in place.
+
+        Returns:
+            True when state was successfully loaded, False otherwise.
+        """
+        if self._state_path is None:
+            logger.debug("load() skipped: no state_path configured")
+            return False
+        try:
+            with open(self._state_path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+            loaded = payload["accuracies"]
+            if not isinstance(loaded, dict):
+                raise TypeError("'accuracies' must be a JSON object")
+            merged = dict(self._initial)
+            for name, value in loaded.items():
+                merged[str(name)] = self._sanitize_accuracy(
+                    float(value), model=str(name)
+                )
+        except FileNotFoundError:
+            logger.info(
+                "No ensemble state at %s; using initial accuracies", self._state_path
+            )
+            self._accuracies = dict(self._initial)
+            return False
+        except (OSError, ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "Corrupt or unreadable ensemble state at %s (%s); "
+                "falling back to initial accuracies",
+                self._state_path,
+                exc,
+            )
+            self._accuracies = dict(self._initial)
+            return False
+        self._accuracies = merged
+        logger.debug("Loaded ensemble state from %s", self._state_path)
+        return True
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _sanitize_accuracy(value: float, model: str = "?") -> float:
+        """Clamp an accuracy to ``[0, 1]``; non-finite values become 0.0."""
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            logger.warning("Non-numeric accuracy %r for %s; using 0.0", value, model)
+            return 0.0
+        if not math.isfinite(value):
+            logger.warning("Non-finite accuracy %r for %s; using 0.0", value, model)
+            return 0.0
+        if value < 0.0 or value > 1.0:
+            clamped = min(max(value, 0.0), 1.0)
+            logger.warning(
+                "Accuracy %.4f for %s outside [0, 1]; clamped to %.1f",
+                value,
+                model,
+                clamped,
+            )
+            return clamped
+        return value
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"{type(self).__name__}(models={sorted(self._accuracies)}, "
+            f"ema_alpha={self._ema_alpha}, state_path={self._state_path!r})"
+        )

--- a/trading/signals/filters.py
+++ b/trading/signals/filters.py
@@ -1,0 +1,408 @@
+"""Signal-quality filters for the profitability roadmap (items #2, #6-#9).
+
+This module provides pure, dependency-light (stdlib + numpy + pandas) gate
+functions that sit between a raw model/strategy signal and order execution.
+Each filter answers one question about signal quality:
+
+- :func:`rsi_gate` -- item #2: veto BUYs into overbought / SELLs into
+  oversold conditions.
+- :func:`has_momentum` -- item #6: require the last N closes to already be
+  moving in the trade direction before entering.
+- :func:`detect_bb_squeeze` -- item #7: detect Bollinger-band volatility
+  squeezes (compressed bands = chop risk, avoid entering).
+- :func:`is_optimal_trading_hour` -- item #8: only trade during the
+  historically liquid UTC hours (default 14:00-22:59, the US session).
+- :func:`detect_macd_divergence` -- item #9: spot short-term price/MACD
+  histogram divergences that either veto a trade or (optionally) generate
+  one.
+
+:func:`apply_signal_filters` composes all five with per-filter enable flags.
+
+How to use::
+
+    from trading.signals.filters import apply_signal_filters
+
+    signal, confidence, reasons = apply_signal_filters(
+        "BUY",
+        0.82,
+        candles_df,          # DataFrame with 'close' (+ 'macd_histogram')
+        rsi=latest_rsi,      # optional; RSI gate is skipped when None
+        config={"trading_hours": False},  # per-filter enable flags
+    )
+    if signal == "HOLD":
+        logger.info("trade vetoed: %s", reasons)
+
+Design notes:
+
+- All functions degrade gracefully: short, empty, missing-column, or NaN
+  data returns a neutral answer (``False`` / ``None`` / unchanged signal)
+  instead of raising, so the bot keeps running in CI and in production
+  when a data feed hiccups.
+- The composite filter is conservative: it only ever *downgrades* an
+  actionable signal to HOLD, except for the opt-in MACD divergence
+  override (``config["macd_divergence_override"]``) which may promote an
+  *incoming* HOLD to BUY/SELL at confidence 0.75. The override never
+  resurrects a signal that another filter just blocked in the same call.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+BUY = "BUY"
+SELL = "SELL"
+HOLD = "HOLD"
+
+#: Default enable flags consumed by :func:`apply_signal_filters`. Copy and
+#: tweak (or pass a partial dict) to switch individual filters off.
+DEFAULT_FILTER_CONFIG: dict[str, bool] = {
+    "rsi_gate": True,
+    "momentum": True,
+    "bb_squeeze": True,
+    "trading_hours": True,
+    "macd_divergence": True,
+    # Opt-in: allow a detected divergence to turn an incoming HOLD into a
+    # BUY/SELL at confidence 0.75.
+    "macd_divergence_override": False,
+}
+
+
+def _normalize_signal(signal: object) -> str:
+    """Map arbitrary input to one of BUY/SELL/HOLD (unknown -> HOLD)."""
+    if isinstance(signal, str):
+        normalized = signal.strip().upper()
+        if normalized in (BUY, SELL, HOLD):
+            return normalized
+    logger.warning("Unknown signal %r treated as HOLD", signal)
+    return HOLD
+
+
+def _last_closes(data: pd.DataFrame | None, count: int) -> np.ndarray | None:
+    """Return the last ``count`` closes as float array, or None if unavailable."""
+    if data is None or not isinstance(data, pd.DataFrame) or "close" not in data:
+        return None
+    if len(data) < count:
+        return None
+    return data["close"].to_numpy(dtype=float)[-count:]
+
+
+def rsi_gate(
+    signal: str,
+    rsi: float | None,
+    overbought: float = 70.0,
+    oversold: float = 30.0,
+) -> tuple[str, str | None]:
+    """Veto trades that chase an already-stretched RSI (roadmap item #2).
+
+    Blocks a BUY when ``rsi > overbought`` (buying into an overbought
+    market) and a SELL when ``rsi < oversold`` (selling into an oversold
+    market). Boundary values are allowed through (strict comparison).
+
+    Args:
+        signal: 'BUY', 'SELL' or 'HOLD' (case-insensitive).
+        rsi: Latest RSI reading (0-100). ``None`` or NaN skips the gate.
+        overbought: RSI above which BUYs are blocked.
+        oversold: RSI below which SELLs are blocked.
+
+    Returns:
+        ``(signal, None)`` when the trade passes, or ``('HOLD', reason)``
+        when it is blocked.
+    """
+    normalized = _normalize_signal(signal)
+    if rsi is None or normalized == HOLD:
+        return normalized, None
+    # NaN comparisons are False, so a NaN RSI naturally passes through.
+    if normalized == BUY and rsi > overbought:
+        reason = f"rsi_gate: RSI {rsi:.1f} > overbought {overbought:.1f}, BUY blocked"
+        logger.debug(reason)
+        return HOLD, reason
+    if normalized == SELL and rsi < oversold:
+        reason = f"rsi_gate: RSI {rsi:.1f} < oversold {oversold:.1f}, SELL blocked"
+        logger.debug(reason)
+        return HOLD, reason
+    return normalized, None
+
+
+def has_momentum(data: pd.DataFrame, direction: str, bars: int = 2) -> bool:
+    """Check that price is already moving in the trade direction (item #6).
+
+    Looks at the last ``bars`` closes and requires each one to have moved
+    versus its predecessor: strictly rising for 'BUY', strictly falling
+    for 'SELL'. This filters out counter-trend entries into flat or
+    opposing tape.
+
+    Args:
+        data: DataFrame with a ``close`` column.
+        direction: 'BUY' (rising) or 'SELL' (falling), case-insensitive.
+        bars: Number of consecutive closes that must confirm the move.
+
+    Returns:
+        True only when momentum is confirmed. Returns False on
+        insufficient data (``len(data) < bars + 1``), missing column,
+        NaN closes, non-positive ``bars``, or an unknown direction --
+        i.e. "cannot confirm" is treated as "no momentum".
+    """
+    if bars < 1:
+        logger.debug("has_momentum: non-positive bars=%d -> False", bars)
+        return False
+    normalized = _normalize_signal(direction)
+    if normalized not in (BUY, SELL):
+        return False
+    closes = _last_closes(data, bars + 1)
+    if closes is None:
+        return False
+    moves = np.diff(closes)
+    if normalized == BUY:
+        return bool(np.all(moves > 0))
+    return bool(np.all(moves < 0))
+
+
+def detect_bb_squeeze(
+    data: pd.DataFrame,
+    window: int = 20,
+    num_std: float = 2.0,
+    squeeze_ratio: float = 0.75,
+) -> bool:
+    """Detect a Bollinger-band volatility squeeze (roadmap item #7).
+
+    Computes the normalized band width ``(upper - lower) / close`` where
+    the bands are the rolling ``window`` mean +/- ``num_std`` standard
+    deviations of the close. A squeeze is flagged when the *current*
+    width has compressed below ``squeeze_ratio`` times its own rolling
+    ``window``-bar average -- i.e. volatility is unusually low versus its
+    recent norm, which typically precedes a breakout and makes
+    mean-reversion entries risky.
+
+    Args:
+        data: DataFrame with a ``close`` column. Needs at least
+            ``2 * window - 1`` rows for a fully-formed comparison.
+        window: Rolling window for both the bands and the width baseline.
+        num_std: Band width in standard deviations.
+        squeeze_ratio: Current width must be below this fraction of the
+            average width to count as a squeeze.
+
+    Returns:
+        True when a squeeze is active; False otherwise, including on
+        insufficient/NaN data or a degenerate (zero-width) baseline.
+    """
+    if (
+        data is None
+        or not isinstance(data, pd.DataFrame)
+        or "close" not in data
+        or len(data) < 2 * window - 1
+    ):
+        return False
+    close = data["close"].astype(float)
+    mean = close.rolling(window).mean()
+    std = close.rolling(window).std()
+    upper = mean + num_std * std
+    lower = mean - num_std * std
+    with np.errstate(divide="ignore", invalid="ignore"):
+        width = (upper - lower) / close
+    baseline = width.rolling(window).mean()
+    current_width = width.iloc[-1]
+    current_baseline = baseline.iloc[-1]
+    if (
+        not np.isfinite(current_width)
+        or not np.isfinite(current_baseline)
+        or current_baseline <= 0
+    ):
+        return False
+    squeezed = bool(current_width < squeeze_ratio * current_baseline)
+    if squeezed:
+        logger.debug(
+            "bb_squeeze: width %.5f < %.2f * baseline %.5f",
+            current_width,
+            squeeze_ratio,
+            current_baseline,
+        )
+    return squeezed
+
+
+def is_optimal_trading_hour(
+    now: datetime | None = None,
+    optimal_hours: Iterable[int] = range(14, 23),
+) -> bool:
+    """Gate trading to the most liquid UTC hours (roadmap item #8).
+
+    The default window 14-22 UTC covers the US session overlap where BTC
+    volume and spreads are historically most favorable.
+
+    Args:
+        now: Time to evaluate; injectable for tests. Defaults to the
+            current UTC time. Naive datetimes are assumed to already be
+            UTC; aware datetimes are converted.
+        optimal_hours: Container of allowed UTC hours (0-23).
+
+    Returns:
+        True when the UTC hour of ``now`` is in ``optimal_hours``.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is not None:
+        now = now.astimezone(timezone.utc)
+    return now.hour in optimal_hours
+
+
+def detect_macd_divergence(data: pd.DataFrame) -> str | None:
+    """Spot a short-term price/MACD-histogram divergence (roadmap item #9).
+
+    Compares the direction of the last two closes against the direction
+    of the last two ``macd_histogram`` values:
+
+    - price down while histogram up -> ``'BULLISH_DIVERGENCE'``
+      (selling pressure fading; upside reversal risk).
+    - price up while histogram down -> ``'BEARISH_DIVERGENCE'``
+      (buying pressure fading; downside reversal risk).
+
+    Args:
+        data: DataFrame with ``close`` and ``macd_histogram`` columns and
+            at least 2 rows.
+
+    Returns:
+        The divergence label, or ``None`` when there is no divergence or
+        the data is insufficient (missing columns, < 2 rows, NaNs, flat
+        values).
+    """
+    if (
+        data is None
+        or not isinstance(data, pd.DataFrame)
+        or "close" not in data
+        or "macd_histogram" not in data
+        or len(data) < 2
+    ):
+        return None
+    closes = data["close"].to_numpy(dtype=float)[-2:]
+    hist = data["macd_histogram"].to_numpy(dtype=float)[-2:]
+    price_up = closes[1] > closes[0]
+    price_down = closes[1] < closes[0]
+    hist_up = hist[1] > hist[0]
+    hist_down = hist[1] < hist[0]
+    if price_down and hist_up:
+        return "BULLISH_DIVERGENCE"
+    if price_up and hist_down:
+        return "BEARISH_DIVERGENCE"
+    return None
+
+
+def apply_signal_filters(
+    signal: str,
+    confidence: float,
+    data: pd.DataFrame,
+    *,
+    rsi: float | None = None,
+    now: datetime | None = None,
+    config: dict[str, bool] | None = None,
+) -> tuple[str, float, list[str]]:
+    """Run a signal through every quality filter and veto weak setups.
+
+    Evaluates all enabled filters against the *incoming* signal so the
+    returned reasons list every objection at once (useful for logging and
+    tuning). If any filter objects, the signal is downgraded to
+    ``('HOLD', 0.0)``.
+
+    Filters and their config flags (all enabled by default, see
+    :data:`DEFAULT_FILTER_CONFIG`):
+
+    - ``rsi_gate`` -- skipped when ``rsi`` is None.
+    - ``momentum`` -- requires the last 2 closes to confirm direction;
+      blocks when data is too short to confirm (conservative).
+    - ``bb_squeeze`` -- blocks entries while a volatility squeeze is on.
+    - ``trading_hours`` -- blocks outside 14-22 UTC.
+    - ``macd_divergence`` -- blocks a BUY on bearish divergence and a
+      SELL on bullish divergence.
+    - ``macd_divergence_override`` (default **False**) -- when True and
+      the *incoming* signal is HOLD, a detected divergence promotes it to
+      BUY (bullish) or SELL (bearish) at confidence 0.75. It never
+      overrides a HOLD produced by another filter in the same call.
+
+    Args:
+        signal: 'BUY', 'SELL' or 'HOLD' (case-insensitive; unknown values
+            are treated as HOLD).
+        confidence: Confidence of the incoming signal (passed through on
+            success, zeroed on veto).
+        data: Candle DataFrame with ``close`` (and ``macd_histogram`` for
+            the divergence checks).
+        rsi: Latest RSI value for the RSI gate; None skips that gate.
+        now: Injectable timestamp for the trading-hours gate.
+        config: Partial override of :data:`DEFAULT_FILTER_CONFIG`.
+
+    Returns:
+        ``(signal, confidence, reasons)`` -- the possibly-downgraded (or
+        divergence-promoted) signal, its confidence, and the list of
+        human-readable veto/override reasons (empty when nothing fired).
+    """
+    cfg = dict(DEFAULT_FILTER_CONFIG)
+    if config:
+        cfg.update(config)
+
+    try:
+        confidence = float(confidence)
+    except (TypeError, ValueError):
+        confidence = 0.0
+
+    normalized = _normalize_signal(signal)
+    reasons: list[str] = []
+
+    if normalized in (BUY, SELL):
+        if cfg.get("rsi_gate", True) and rsi is not None:
+            _, reason = rsi_gate(normalized, rsi)
+            if reason is not None:
+                reasons.append(reason)
+
+        if cfg.get("momentum", True) and not has_momentum(data, normalized):
+            direction = "rising" if normalized == BUY else "falling"
+            reasons.append(
+                f"momentum: last closes not consistently {direction},"
+                f" {normalized} blocked"
+            )
+
+        if cfg.get("bb_squeeze", True) and detect_bb_squeeze(data):
+            reasons.append(
+                f"bb_squeeze: volatility squeeze active, {normalized} blocked"
+            )
+
+        if cfg.get("trading_hours", True) and not is_optimal_trading_hour(now):
+            reasons.append(
+                f"trading_hours: outside optimal UTC hours, {normalized} blocked"
+            )
+
+        if cfg.get("macd_divergence", True):
+            divergence = detect_macd_divergence(data)
+            if (normalized == BUY and divergence == "BEARISH_DIVERGENCE") or (
+                normalized == SELL and divergence == "BULLISH_DIVERGENCE"
+            ):
+                reasons.append(
+                    f"macd_divergence: {divergence} contradicts {normalized}"
+                )
+
+        if reasons:
+            logger.info(
+                "Signal %s downgraded to HOLD by %d filter(s): %s",
+                normalized,
+                len(reasons),
+                "; ".join(reasons),
+            )
+            return HOLD, 0.0, reasons
+        return normalized, confidence, []
+
+    # Incoming HOLD: optionally let a divergence generate a signal.
+    if cfg.get("macd_divergence_override", False):
+        divergence = detect_macd_divergence(data)
+        if divergence == "BULLISH_DIVERGENCE":
+            reasons.append("macd_divergence_override: BULLISH_DIVERGENCE -> BUY")
+            logger.info(reasons[-1])
+            return BUY, 0.75, reasons
+        if divergence == "BEARISH_DIVERGENCE":
+            reasons.append("macd_divergence_override: BEARISH_DIVERGENCE -> SELL")
+            logger.info(reasons[-1])
+            return SELL, 0.75, reasons
+
+    return HOLD, confidence, []

--- a/trading/signals/mtf.py
+++ b/trading/signals/mtf.py
@@ -1,0 +1,277 @@
+"""Multi-timeframe (MTF) trend alignment signals (roadmap item #14).
+
+How it works
+------------
+A simple-moving-average (SMA) crossover is computed independently on several
+timeframes (e.g. 15m / 1h / 4h). Each timeframe yields ``'BUY'``, ``'SELL'``
+or ``'HOLD'`` depending on whether the fast SMA is above/below the slow SMA
+by more than a small threshold (0.1% by default, to filter out noise around
+the crossover point). The overall ("aligned") signal is only ``'BUY'`` when
+*every* timeframe agrees on ``'BUY'`` (and ``'SELL'`` when all agree on
+``'SELL'``); any disagreement or missing data degrades to ``'HOLD'``.
+Requiring agreement across timeframes filters counter-trend entries: a
+15-minute bounce inside a 4-hour downtrend will not produce a ``'BUY'``.
+
+How to use it
+-------------
+The kline source is dependency-injected so the module stays free of network
+and exchange-client dependencies (stdlib + numpy + pandas only)::
+
+    from trading.signals.mtf import MTFAnalyzer
+    from utils.price_fetcher import PriceFetcher
+
+    fetcher = PriceFetcher(...)
+    mtf = MTFAnalyzer(fetch_klines=fetcher.get_historical_klines)
+    result = mtf.get_signal("BTCUSDT")
+    # result == {
+    #     "symbol": "BTCUSDT",
+    #     "signals": {"15m": "BUY", "1h": "BUY", "4h": "HOLD"},
+    #     "aligned": "HOLD",
+    # }
+
+``fetch_klines(symbol, interval, limit)`` may return either a
+``pd.DataFrame`` with a ``close`` column (what
+``PriceFetcher.get_historical_klines`` returns) or a raw list of Binance
+kline lists where index 4 is the close price. Any fetch failure (exception,
+``None``, empty or malformed data) maps that timeframe to ``'HOLD'``;
+``get_signal`` never raises.
+
+``sma_trend_signal`` can also be used standalone on any DataFrame that has a
+``close`` column.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+#: Signal constants (shared vocabulary with the rest of the bot).
+BUY = "BUY"
+SELL = "SELL"
+HOLD = "HOLD"
+
+#: Minimum relative SMA separation for a directional signal (0.1%).
+DEFAULT_THRESHOLD = 0.001
+
+#: Position of the close price in a raw Binance kline list.
+_KLINE_CLOSE_INDEX = 4
+
+#: What an injected kline fetcher may return.
+KlinesData = Union[pd.DataFrame, Sequence[Sequence[object]]]
+FetchKlines = Callable[[str, str, int], Optional[KlinesData]]
+
+
+def _coerce_close(data: Optional[KlinesData]) -> pd.Series:
+    """Extract a numeric close-price Series from heterogeneous kline data.
+
+    Accepts a DataFrame with a ``close`` column, a DataFrame whose 5th
+    column is the close (raw klines loaded without headers), or a
+    list/tuple/ndarray of kline rows where index 4 is the close. Values are
+    coerced to float and NaNs dropped. Returns an empty Series when the
+    data is missing, empty, or malformed (never raises).
+    """
+    if data is None:
+        return pd.Series(dtype=float)
+
+    try:
+        if isinstance(data, pd.DataFrame):
+            if data.empty:
+                return pd.Series(dtype=float)
+            if "close" in data.columns:
+                raw = data["close"]
+            elif data.shape[1] > _KLINE_CLOSE_INDEX:
+                raw = data.iloc[:, _KLINE_CLOSE_INDEX]
+            else:
+                logger.warning(
+                    "Kline DataFrame has no 'close' column and too few "
+                    "columns (%d) to infer one",
+                    data.shape[1],
+                )
+                return pd.Series(dtype=float)
+        else:
+            rows = list(data)
+            closes = [
+                row[_KLINE_CLOSE_INDEX]
+                for row in rows
+                if isinstance(row, (list, tuple, np.ndarray))
+                and len(row) > _KLINE_CLOSE_INDEX
+            ]
+            raw = pd.Series(closes, dtype=object)
+
+        close = pd.to_numeric(raw, errors="coerce").dropna()
+        return close.reset_index(drop=True).astype(float)
+    except Exception:
+        logger.warning("Failed to coerce kline data to close series", exc_info=True)
+        return pd.Series(dtype=float)
+
+
+def sma_trend_signal(
+    data: Optional[pd.DataFrame],
+    fast: int = 20,
+    slow: int = 50,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> str:
+    """Classify the trend of one timeframe via an SMA(fast)/SMA(slow) spread.
+
+    Returns ``'BUY'`` when the fast SMA exceeds the slow SMA by more than
+    ``threshold`` (relative, default 0.1%), ``'SELL'`` when it is below by
+    more than ``threshold``, and ``'HOLD'`` otherwise. Insufficient data
+    (fewer than ``slow`` valid closes after dropping NaNs), missing/empty
+    input, or invalid parameters all return ``'HOLD'`` — this function
+    never raises on bad market data.
+
+    Args:
+        data: DataFrame with a ``close`` column (raw kline rows also
+            tolerated, see :func:`_coerce_close`).
+        fast: Fast SMA window (must be ``0 < fast <= slow``).
+        slow: Slow SMA window; also the minimum number of closes required.
+        threshold: Relative separation required for a directional signal.
+
+    Returns:
+        ``'BUY'``, ``'SELL'`` or ``'HOLD'``.
+    """
+    if fast <= 0 or slow <= 0 or fast > slow:
+        logger.warning(
+            "Invalid SMA windows fast=%s slow=%s; returning HOLD", fast, slow
+        )
+        return HOLD
+
+    close = _coerce_close(data)
+    if len(close) < slow:
+        logger.debug(
+            "Not enough closes for SMA trend (%d < %d); returning HOLD",
+            len(close),
+            slow,
+        )
+        return HOLD
+
+    sma_fast = float(close.iloc[-fast:].mean())
+    sma_slow = float(close.iloc[-slow:].mean())
+    if not np.isfinite(sma_fast) or not np.isfinite(sma_slow) or sma_slow <= 0:
+        logger.warning(
+            "Non-finite or non-positive SMAs (fast=%s slow=%s); returning HOLD",
+            sma_fast,
+            sma_slow,
+        )
+        return HOLD
+
+    spread = sma_fast / sma_slow - 1.0
+    if spread > threshold:
+        return BUY
+    if spread < -threshold:
+        return SELL
+    return HOLD
+
+
+class MTFAnalyzer:
+    """Multi-timeframe SMA trend alignment.
+
+    Fetches klines for each configured timeframe through an injected
+    ``fetch_klines(symbol, interval, limit)`` callable, computes a per-
+    timeframe :func:`sma_trend_signal`, and reports the aligned consensus:
+    ``'BUY'`` only if every timeframe says ``'BUY'``, ``'SELL'`` only if
+    every timeframe says ``'SELL'``, otherwise ``'HOLD'``.
+
+    Live wiring::
+
+        mtf = MTFAnalyzer(fetch_klines=price_fetcher.get_historical_klines)
+        if mtf.get_signal("BTCUSDT")["aligned"] == "BUY":
+            ...
+
+    Any per-timeframe fetch failure (raised exception, ``None``, empty or
+    malformed data) maps that timeframe to ``'HOLD'`` — which forces the
+    aligned signal to ``'HOLD'`` — and :meth:`get_signal` never raises.
+
+    Args:
+        fetch_klines: Callable returning a DataFrame with a ``close``
+            column or a list of raw kline lists (index 4 = close).
+        timeframes: Interval strings to analyze (order preserved in the
+            result). Must be non-empty.
+        limit: Number of klines requested per timeframe; must be at least
+            ``slow`` for directional signals to be possible.
+        fast: Fast SMA window passed to :func:`sma_trend_signal`.
+        slow: Slow SMA window passed to :func:`sma_trend_signal`.
+    """
+
+    def __init__(
+        self,
+        fetch_klines: FetchKlines,
+        timeframes: Tuple[str, ...] = ("15m", "1h", "4h"),
+        limit: int = 60,
+        fast: int = 20,
+        slow: int = 50,
+    ) -> None:
+        if not callable(fetch_klines):
+            raise TypeError("fetch_klines must be callable")
+        self.fetch_klines = fetch_klines
+        self.timeframes: Tuple[str, ...] = tuple(timeframes)
+        self.limit = int(limit)
+        self.fast = int(fast)
+        self.slow = int(slow)
+        if self.limit < self.slow:
+            logger.warning(
+                "limit=%d is below slow=%d; every timeframe will return HOLD",
+                self.limit,
+                self.slow,
+            )
+
+    def _timeframe_signal(self, symbol: str, interval: str) -> str:
+        """Fetch one timeframe and classify it; failures map to HOLD."""
+        try:
+            raw = self.fetch_klines(symbol, interval, self.limit)
+        except Exception:
+            logger.warning(
+                "fetch_klines failed for %s %s; treating as HOLD",
+                symbol,
+                interval,
+                exc_info=True,
+            )
+            return HOLD
+
+        close = _coerce_close(raw)
+        if close.empty:
+            logger.debug("No usable closes for %s %s; HOLD", symbol, interval)
+            return HOLD
+        return sma_trend_signal(
+            pd.DataFrame({"close": close}), fast=self.fast, slow=self.slow
+        )
+
+    def get_signal(self, symbol: str) -> Dict[str, object]:
+        """Compute per-timeframe signals and their aligned consensus.
+
+        Args:
+            symbol: Trading pair symbol, e.g. ``"BTCUSDT"``.
+
+        Returns:
+            ``{"symbol": symbol, "signals": {interval: signal, ...},
+            "aligned": "BUY"|"SELL"|"HOLD"}``. Never raises: any failure
+            degrades the affected timeframe (and hence the aligned
+            signal) to ``'HOLD'``.
+        """
+        signals: Dict[str, str] = {}
+        for interval in self.timeframes:
+            try:
+                signals[interval] = self._timeframe_signal(symbol, interval)
+            except Exception:  # pragma: no cover - defensive belt-and-braces
+                logger.error(
+                    "Unexpected error computing %s %s signal; HOLD",
+                    symbol,
+                    interval,
+                    exc_info=True,
+                )
+                signals[interval] = HOLD
+
+        if signals and all(s == BUY for s in signals.values()):
+            aligned = BUY
+        elif signals and all(s == SELL for s in signals.values()):
+            aligned = SELL
+        else:
+            aligned = HOLD
+
+        logger.debug("MTF %s: signals=%s aligned=%s", symbol, signals, aligned)
+        return {"symbol": symbol, "signals": signals, "aligned": aligned}

--- a/trading/signals/order_flow.py
+++ b/trading/signals/order_flow.py
@@ -1,0 +1,182 @@
+"""Order-book imbalance signals (profitability roadmap item #12).
+
+How it works
+------------
+The order book snapshot returned by the executor (Binance ``get_order_book``
+shape) contains price levels as ``{'bids': [[price, qty], ...],
+'asks': [[price, qty], ...]}``.  Summing the quantities on each side over the
+top ``depth`` levels gives the resting liquidity near the touch.  The
+normalized imbalance
+
+    imbalance = (bid_liquidity - ask_liquidity) / (bid_liquidity + ask_liquidity)
+
+lies in ``[-1, 1]``: positive values mean buyers dominate the near book
+(bullish pressure), negative values mean sellers dominate (bearish pressure),
+and values near zero mean the book is balanced (no information).
+
+How to use it
+-------------
+>>> book = executor.get_order_book(symbol)  # or {'bids': [], 'asks': []} in paper mode
+>>> imbalance = order_book_imbalance(book, depth=10)
+>>> order_flow_signal(imbalance)
+'BUY'
+>>> confirmed, imb = confirm_signal_with_flow("BUY", book)
+>>> if not confirmed:
+...     pass  # skip the trade: the order book contradicts the strategy signal
+
+All functions degrade gracefully: empty/missing/malformed books (paper mode
+returns empty lists) yield a neutral ``0.0`` imbalance and never raise, so the
+confirmation step becomes a no-op rather than blocking trading.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: Signal labels used across the bot.
+BUY = "BUY"
+SELL = "SELL"
+NEUTRAL = "NEUTRAL"
+
+#: Default number of book levels per side used to measure liquidity.
+DEFAULT_DEPTH = 10
+
+#: Default minimum |imbalance| required for a directional flow signal.
+DEFAULT_THRESHOLD = 0.15
+
+
+def _side_liquidity(levels: Any, depth: int) -> float:
+    """Sum the quantities of the top ``depth`` levels of one book side.
+
+    Malformed levels (wrong shape, non-numeric, negative or non-finite
+    quantities) are skipped instead of raising, so a partially corrupt
+    snapshot still produces a usable number.
+    """
+    if not isinstance(levels, Sequence) or isinstance(levels, (str, bytes)):
+        return 0.0
+
+    total = 0.0
+    for level in list(levels)[:depth]:
+        try:
+            qty = float(level[1])
+        except (TypeError, ValueError, IndexError, KeyError):
+            logger.debug("Skipping malformed order-book level: %r", level)
+            continue
+        if not math.isfinite(qty) or qty < 0.0:
+            logger.debug("Skipping non-finite/negative quantity: %r", level)
+            continue
+        total += qty
+    return total
+
+
+def order_book_imbalance(
+    order_book: Mapping[str, Any] | None, depth: int = DEFAULT_DEPTH
+) -> float:
+    """Compute the normalized bid/ask liquidity imbalance of an order book.
+
+    Args:
+        order_book: Snapshot shaped like ``{'bids': [[price, qty], ...],
+            'asks': [[price, qty], ...]}``.  Prices/quantities may be strings
+            (Binance REST returns strings); they are coerced to ``float``.
+        depth: Number of levels per side to include (top of book first).
+
+    Returns:
+        ``(bid_liq - ask_liq) / (bid_liq + ask_liq)`` clamped to ``[-1, 1]``.
+        Returns ``0.0`` (neutral) when the book is empty, missing, malformed,
+        or has no measurable liquidity — e.g. paper mode returning
+        ``{'bids': [], 'asks': []}``.
+    """
+    if not isinstance(order_book, Mapping):
+        if order_book is not None:
+            logger.debug("order_book is not a mapping: %r", type(order_book))
+        return 0.0
+    if depth <= 0:
+        logger.debug("Non-positive depth=%s; returning neutral imbalance", depth)
+        return 0.0
+
+    bid_liq = _side_liquidity(order_book.get("bids"), depth)
+    ask_liq = _side_liquidity(order_book.get("asks"), depth)
+    total = bid_liq + ask_liq
+    if total <= 0.0 or not math.isfinite(total):
+        return 0.0
+
+    imbalance = (bid_liq - ask_liq) / total
+    # Mathematically already in [-1, 1] for non-negative liquidity, but clamp
+    # defensively against float artifacts.
+    return max(-1.0, min(1.0, imbalance))
+
+
+def order_flow_signal(imbalance: float, threshold: float = DEFAULT_THRESHOLD) -> str:
+    """Map an imbalance value to a directional flow signal.
+
+    Args:
+        imbalance: Value from :func:`order_book_imbalance`, ideally in
+            ``[-1, 1]``.  ``NaN`` is treated as no information.
+        threshold: Minimum magnitude (exclusive) required for a directional
+            call; values in ``[-threshold, +threshold]`` are ``'NEUTRAL'``.
+
+    Returns:
+        ``'BUY'`` when ``imbalance > threshold``, ``'SELL'`` when
+        ``imbalance < -threshold``, otherwise ``'NEUTRAL'``.
+    """
+    try:
+        value = float(imbalance)
+    except (TypeError, ValueError):
+        logger.debug("Non-numeric imbalance %r; returning NEUTRAL", imbalance)
+        return NEUTRAL
+    if math.isnan(value):
+        return NEUTRAL
+    if value > threshold:
+        return BUY
+    if value < -threshold:
+        return SELL
+    return NEUTRAL
+
+
+def confirm_signal_with_flow(
+    signal: str,
+    order_book: Mapping[str, Any] | None,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> tuple[bool, float]:
+    """Check whether order flow confirms (or at least does not contradict) a
+    strategy signal.
+
+    The confirmation is intentionally permissive: a ``'NEUTRAL'`` flow signal
+    carries no information, so it never blocks a trade.  Only an outright
+    contradiction (e.g. strategy says ``'BUY'`` while the book is ask-heavy
+    beyond ``threshold``) vetoes the signal.  Non-directional strategy
+    signals (anything other than ``'BUY'``/``'SELL'``, e.g. ``'HOLD'``)
+    cannot be contradicted and are always confirmed.
+
+    Args:
+        signal: Strategy signal, typically ``'BUY'`` or ``'SELL'``
+            (case-insensitive).
+        order_book: Order book snapshot; see :func:`order_book_imbalance`.
+        threshold: Imbalance magnitude needed for the flow to take a side.
+
+    Returns:
+        ``(confirmed, imbalance)`` where ``confirmed`` is ``True`` when the
+        flow agrees with ``signal`` or is neutral/uninformative, and
+        ``imbalance`` is the computed order-book imbalance (``0.0`` for
+        empty/paper-mode books, which therefore never block).
+    """
+    imbalance = order_book_imbalance(order_book)
+    flow = order_flow_signal(imbalance, threshold)
+
+    normalized = signal.strip().upper() if isinstance(signal, str) else ""
+    if normalized not in (BUY, SELL):
+        return True, imbalance
+
+    confirmed = flow == NEUTRAL or flow == normalized
+    if not confirmed:
+        logger.info(
+            "Order flow contradicts signal %s (flow=%s, imbalance=%.4f)",
+            normalized,
+            flow,
+            imbalance,
+        )
+    return confirmed, imbalance


### PR DESCRIPTION
Implements every item in [`profitability_roadmap.md`](https://github.com/cluster2600/ELVIS/blob/main/profitability_roadmap.md). Full status matrix in [`docs/profitability_roadmap_implementation.md`](docs/profitability_roadmap_implementation.md).

## Honesty first
The roadmap's projections (35%→75% win rate, $1k→$25k/month) are **estimates, not verified results**. This PR delivers the *mechanisms* — each unit-tested — with env flags so impact can be measured one at a time in paper trading. No performance claims are made here.

## What's in it (4 commits)

**1. `fix:` track load-bearing WIP** — `main.py` already imported `trading/analysis/market_regime_detector.py` (#1), `trading/analysis/high_winrate_filter.py`, and `trading/cooldown/trade_cooldown_manager.py`, but none were tracked — **a fresh clone of main couldn't start the bot**. Now committed (formatted).

**2. `feat:` the mechanism modules + 317 tests** — dependency-light (stdlib+numpy+pandas; import clean without torch/talib, so CI runs them):
| Items | Module |
|---|---|
| #2 RSI, #6 momentum, #7 BB squeeze, #8 hours, #9 MACD divergence | `trading/signals/filters.py` |
| #3 volume sizing, #13 Kelly | `trading/risk/position_sizing.py` |
| #4 trailing stop, #10 regime take-profit | `trading/execution/exits.py` |
| #5 all-in fee gate | `trading/fees/fee_gate.py` |
| #12 order-book imbalance | `trading/signals/order_flow.py` |
| #14 multi-timeframe alignment | `trading/signals/mtf.py` |
| #11 adaptive ensemble weights | `trading/signals/adaptive_ensemble.py` |
| #15 walk-forward optimizer | `trading/optimization/walk_forward.py` |

**3. `feat:` main-loop wiring** — four surgical, env-toggled stages mirroring the existing lazy-import pattern, each try/except'd so a gate failure logs and never kills the loop: signal gates → regime cache → volume/Kelly sizing → fee gate before execution → trailing stop + dynamic TP in the position loop.

**4. `docs:`** the status matrix, flag defaults and rationale, walk-forward usage, and the item-11 caveat.

## Flags (defaults chosen for safe paper trading)
On by default: `ELVIS_ROADMAP_FILTERS`, `ELVIS_VOLUME_SIZING`, `ELVIS_FEE_GATE`, `ELVIS_TRAILING_STOP`, `ELVIS_DYNAMIC_TP`. Off by default (documented reasons): `ELVIS_ORDER_FLOW` (paper books are empty), `ELVIS_KELLY_SIZING` (needs ≥20 closed trades), `ELVIS_MTF` (3x kline API calls).

## Two conscious deviations from the roadmap text
- **Dynamic TP uses percentages, not absolute dollars** — a $0.10 target is meaningless across BTC price levels; regime→pct (TRENDING 5% … CHOPPY 0.1%) preserves the intent.
- **Item #11 is module-only** — the loop doesn't yet record per-model accuracy per closed trade; wiring invented accuracies would be theater. The feedback pipeline is the natural follow-up.

## Verification
- **317 new tests**, all passing; pinned math for Kelly, fee arithmetic, EMA weight updates.
- **Full CI-equivalent suite: 606 passed, 3 skipped, 0 failed** (tracked tests + new ones).
- `import main` clean; black/isort/flake8(E9,F63,F7,F82) clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)