### PR TITLE
fix(ci): repair always-failing Security Scan + Docker jobs on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,12 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # SARIF upload
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       with:
@@ -102,9 +105,9 @@ jobs:
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
-    
+
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'
 
@@ -113,32 +116,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, test]
     if: github.event_name == 'push'
-    
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io (same registry as release.yml)
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-    
-    - name: Log in to Docker Hub
+
+    - name: Log in to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       if: github.ref == 'refs/heads/main'
-    
+
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ secrets.DOCKER_USERNAME }}/elvis-trading-bot
+        images: ghcr.io/cluster2600/elvis
         tags: |
           type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
           type=sha
-    
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
The README's new CI badge exposed that **every push to `main` fails the CI/CD Pipeline** — it wasn't the README; these two jobs have been broken for a while:

## Security Scan
- `github/codeql-action/upload-sarif@v2` → **deprecated hard error** since Jan 2025 → bumped to `@v3`
- Job lacked `security-events: write` → SARIF upload died with "Resource not accessible by integration" → permission added

## Build Docker Image
- Logged into **Docker Hub** with `DOCKER_USERNAME`/`DOCKER_PASSWORD` secrets that don't exist in this repo ("Username and password required"), and tagged images under the empty secret name.
- Switched to **GHCR + `GITHUB_TOKEN`** — the exact registry/image (`ghcr.io/cluster2600/elvis`) that `release.yml` already publishes to. Main pushes now add `:main` and `:sha-*` tags next to the release's version tags; no new secrets needed.

After merge, the next push to `main` should turn the README badge green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)