### PR TITLE
fix: bot never traded — portfolio kill-switch stuck in the $1000 era (+ client timeouts)

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,6 +235,26 @@ def _retrain_strategy_if_due(active_strategy, price_fetcher, logger: logging.Log
         return False
 
 
+def _protection_floor(mode: str, current_balance: float, baseline_state: dict):
+    """Emergency-stop floor for the portfolio-protection check.
+
+    Returns ``(floor, baseline, pct)``. Paper mode measures against the
+    configured ``INITIAL_USDT_BALANCE`` deposit; live mode measures against
+    the FIRST balance observed this session (persisted in
+    ``baseline_state``) — real money must never be judged against the
+    fictional paper deposit. ``ELVIS_PROTECT_FLOOR_PCT`` (default 0.7 = the
+    original lose-more-than-30% rule) scales the floor in both modes.
+    """
+    from config.config import PAPER_TRADING_CONFIG
+
+    pct = float(os.getenv("ELVIS_PROTECT_FLOOR_PCT", "0.7"))
+    if mode == "paper":
+        baseline = float(PAPER_TRADING_CONFIG.get("INITIAL_USDT_BALANCE", 100.0))
+    else:
+        baseline = baseline_state.setdefault("baseline", float(current_balance))
+    return baseline * pct, baseline, pct
+
+
 def main(mode: str, log_level: str):
     """
     Main entry point for the trading bot using dependency injection.
@@ -1170,24 +1190,22 @@ def main(mode: str, log_level: str):
                         # EMERGENCY PORTFOLIO PROTECTION - Check balance before trading
                         try:
                             current_balance = executor.get_account_balance()
-                            # Floor is relative to the CONFIGURED deposit (a
-                            # hardcoded $700 floor from the old $1000 world
+                            # Mode-aware floor (see _protection_floor): paper
+                            # measures against the configured deposit — the old
+                            # hardcoded $700 floor from the $1000 world
                             # emergency-stopped every run once the honest $100
-                            # deposit landed: 100 < 700 on the first cycle).
-                            from config.config import PAPER_TRADING_CONFIG
-
-                            _start_balance = float(
-                                PAPER_TRADING_CONFIG.get("INITIAL_USDT_BALANCE", 100.0)
-                            )
-                            _protect_floor = _start_balance * float(
-                                os.getenv("ELVIS_PROTECT_FLOOR_PCT", "0.7")
+                            # deposit landed — while live measures against the
+                            # session's first observed real balance.
+                            if not hasattr(trading_loop, "_protection_state"):
+                                trading_loop._protection_state = {}
+                            _protect_floor, _baseline, _pct = _protection_floor(
+                                mode, current_balance, trading_loop._protection_state
                             )
                             if current_balance < _protect_floor:
                                 logger.error(
                                     f"🚨 PORTFOLIO PROTECTION: Balance dropped to ${current_balance:.2f}"
-                                    f" (floor ${_protect_floor:.2f} = "
-                                    f"{float(os.getenv('ELVIS_PROTECT_FLOOR_PCT', '0.7')):.0%}"
-                                    f" of ${_start_balance:.2f} deposit)"
+                                    f" (floor ${_protect_floor:.2f} = {_pct:.0%}"
+                                    f" of ${_baseline:.2f} {mode} baseline)"
                                 )
                                 logger.error(
                                     "🚨 EMERGENCY SHUTDOWN - Portfolio protection activated"

--- a/main.py
+++ b/main.py
@@ -1170,9 +1170,24 @@ def main(mode: str, log_level: str):
                         # EMERGENCY PORTFOLIO PROTECTION - Check balance before trading
                         try:
                             current_balance = executor.get_account_balance()
-                            if current_balance < 700:  # If lost more than 30% of $1000
+                            # Floor is relative to the CONFIGURED deposit (a
+                            # hardcoded $700 floor from the old $1000 world
+                            # emergency-stopped every run once the honest $100
+                            # deposit landed: 100 < 700 on the first cycle).
+                            from config.config import PAPER_TRADING_CONFIG
+
+                            _start_balance = float(
+                                PAPER_TRADING_CONFIG.get("INITIAL_USDT_BALANCE", 100.0)
+                            )
+                            _protect_floor = _start_balance * float(
+                                os.getenv("ELVIS_PROTECT_FLOOR_PCT", "0.7")
+                            )
+                            if current_balance < _protect_floor:
                                 logger.error(
                                     f"🚨 PORTFOLIO PROTECTION: Balance dropped to ${current_balance:.2f}"
+                                    f" (floor ${_protect_floor:.2f} = "
+                                    f"{float(os.getenv('ELVIS_PROTECT_FLOOR_PCT', '0.7')):.0%}"
+                                    f" of ${_start_balance:.2f} deposit)"
                                 )
                                 logger.error(
                                     "🚨 EMERGENCY SHUTDOWN - Portfolio protection activated"

--- a/tests/test_protection_floor.py
+++ b/tests/test_protection_floor.py
@@ -1,0 +1,66 @@
+"""Portfolio-protection floor (review findings on #45).
+
+The old hardcoded `balance < 700` floor emergency-stopped every paper run
+once the deposit became $100. The floor must be mode-aware: paper measures
+against the configured deposit, live against the session's first observed
+real balance — never the fictional paper deposit.
+"""
+
+import pytest
+
+from config.config import PAPER_TRADING_CONFIG
+from main import _protection_floor
+
+DEPOSIT = float(PAPER_TRADING_CONFIG["INITIAL_USDT_BALANCE"])
+
+
+def test_paper_floor_is_pct_of_configured_deposit(monkeypatch):
+    monkeypatch.delenv("ELVIS_PROTECT_FLOOR_PCT", raising=False)
+    floor, baseline, pct = _protection_floor(
+        "paper", current_balance=55.0, baseline_state={}
+    )
+    assert baseline == DEPOSIT
+    assert pct == pytest.approx(0.7)
+    assert floor == pytest.approx(DEPOSIT * 0.7)
+
+
+def test_paper_deposit_passes_its_own_floor(monkeypatch):
+    """The exact regression: the starting deposit must clear the floor."""
+    monkeypatch.delenv("ELVIS_PROTECT_FLOOR_PCT", raising=False)
+    floor, _, _ = _protection_floor("paper", DEPOSIT, {})
+    assert DEPOSIT >= floor
+
+
+def test_env_pct_override(monkeypatch):
+    monkeypatch.setenv("ELVIS_PROTECT_FLOOR_PCT", "0.5")
+    floor, _, pct = _protection_floor("paper", 55.0, {})
+    assert pct == pytest.approx(0.5)
+    assert floor == pytest.approx(DEPOSIT * 0.5)
+
+
+def test_live_uses_first_observed_balance_not_paper_deposit(monkeypatch):
+    monkeypatch.delenv("ELVIS_PROTECT_FLOOR_PCT", raising=False)
+    state = {}
+    floor, baseline, _ = _protection_floor("live", 5000.0, state)
+    assert baseline == 5000.0  # real account, not the $100 paper deposit
+    assert floor == pytest.approx(3500.0)
+
+
+def test_live_baseline_sticks_across_iterations(monkeypatch):
+    """A later dip must be measured against the SESSION-START balance,
+    otherwise the floor would chase the balance down and never trigger."""
+    monkeypatch.delenv("ELVIS_PROTECT_FLOOR_PCT", raising=False)
+    state = {}
+    _protection_floor("live", 5000.0, state)
+    floor, baseline, _ = _protection_floor("live", 4000.0, state)
+    assert baseline == 5000.0
+    assert floor == pytest.approx(3500.0)
+    assert 4000.0 >= floor  # -20% survives
+    assert 3400.0 < floor  # -32% trips
+
+
+def test_paper_ignores_live_baseline_state(monkeypatch):
+    monkeypatch.delenv("ELVIS_PROTECT_FLOOR_PCT", raising=False)
+    state = {"baseline": 9999.0}
+    _, baseline, _ = _protection_floor("paper", 50.0, state)
+    assert baseline == DEPOSIT

--- a/utils/price_fetcher.py
+++ b/utils/price_fetcher.py
@@ -86,7 +86,9 @@ class PriceFetcher:
                     # Try to use futures connector first, fallback to spot
                     if FUTURES_AVAILABLE:
                         try:
-                            self.client = UMFutures(key=api_key, secret=api_secret)
+                            self.client = UMFutures(
+                                key=api_key, secret=api_secret, timeout=10
+                            )
                             self.logger.info(
                                 "Using authenticated Binance Futures client"
                             )
@@ -94,14 +96,18 @@ class PriceFetcher:
                             self.logger.warning(
                                 f"Futures client failed, using spot client: {e}"
                             )
-                            self.client = Client(api_key, api_secret)
+                            self.client = Client(
+                                api_key, api_secret, requests_params={"timeout": 10}
+                            )
                             self.logger.info("Using authenticated Binance spot client")
                     else:
-                        self.client = Client(api_key, api_secret)
+                        self.client = Client(
+                            api_key, api_secret, requests_params={"timeout": 10}
+                        )
                         self.logger.info("Using authenticated Binance spot client")
                 else:
                     # Use public client for price data (no trading)
-                    self.client = Client()
+                    self.client = Client(requests_params={"timeout": 10})
                     self.logger.info(
                         "Using public Binance client for price data (no API keys)"
                     )
@@ -150,7 +156,7 @@ class PriceFetcher:
                             spot_client = self._spot_client
                         else:
                             # Create a temporary spot client
-                            spot_client = Client()
+                            spot_client = Client(requests_params={"timeout": 10})
                             self._spot_client = spot_client
                         klines = spot_client.get_historical_klines(
                             symbol=symbol,
@@ -376,7 +382,7 @@ class PriceFetcher:
                     if hasattr(self, "_spot_client"):
                         spot_client = self._spot_client
                     else:
-                        spot_client = Client()
+                        spot_client = Client(requests_params={"timeout": 10})
                         self._spot_client = spot_client
                     ticker = spot_client.get_symbol_ticker(symbol=symbol)
                     price = float(ticker["price"])
@@ -477,7 +483,7 @@ class PriceFetcher:
                     if hasattr(self, "_spot_client"):
                         spot_client = self._spot_client
                     else:
-                        spot_client = Client()
+                        spot_client = Client(requests_params={"timeout": 10})
                         self._spot_client = spot_client
                     klines = spot_client.get_historical_klines(
                         symbol=symbol, interval=interval, limit=limit


### PR DESCRIPTION
## Symptom
The paper bot ran for 70+ minutes looking healthy (klines streaming, TUI updating) while evaluating **zero signals** — no open positions, no new trades.

## Actual root cause (correction from the first version of this PR)
`main.py`'s emergency portfolio protection used a **hardcoded floor from the old \$1000 world**:
```python
if current_balance < 700:  # If lost more than 30% of $1000
    ...
    return  # Exit trading loop
```
Since the honest-accounting change set the paper deposit to **\$100**, every single run tripped this on its *first* iteration (100 < 700) and silently killed the trading loop — while the dashboard and websocket threads kept running, making the bot look alive. Both of today's runs died this way.

**Fix:** the floor is now `ELVIS_PROTECT_FLOOR_PCT` (default 0.7 — same 30%-loss rule) × the configured `INITIAL_USDT_BALANCE`, and the shutdown log prints the floor and the deposit it was computed from.

## Also in this PR: hard client timeouts (real hardening, initially misdiagnosed as the cause)
All 7 `python-binance` client constructions in `utils/price_fetcher.py` had **no request timeout** — a stalled socket in `get_historical_klines` could block a trading iteration forever. Now `requests_params={"timeout": 10}` (spot) / `timeout=10` (UMFutures). A dead connection raises; the loop's per-symbol `try/except` logs and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)