### PR TITLE
feat(dashboard): X-API-Key resolved from OpenBao (secrets/dashboard)

### DIFF
--- a/scripts/native_console_dashboard.py
+++ b/scripts/native_console_dashboard.py
@@ -89,17 +89,12 @@ class NativeConsoleDashboard:
         then OpenBao at secrets/dashboard field api_key — same resolution the
         server itself uses, so vault-backed setups need no env plumbing."""
         if not hasattr(self, "_api_key_resolved"):
-            key = os.getenv("API_KEY")
-            if not key:
-                try:
-                    from utils.secrets_manager import get_enhanced_secrets_manager
+            try:
+                from utils.secrets_manager import resolve_dashboard_api_key
 
-                    key = get_enhanced_secrets_manager().get_secret(
-                        "DASHBOARD_API_KEY", warn_if_missing=False
-                    )
-                except Exception:
-                    key = None
-            self._api_key_resolved = key
+                self._api_key_resolved = resolve_dashboard_api_key()
+            except Exception:
+                self._api_key_resolved = os.getenv("API_KEY")
         return self._api_key_resolved
 
     def _get_json_cached(self, url, params=None, ttl=5.0):

--- a/scripts/native_console_dashboard.py
+++ b/scripts/native_console_dashboard.py
@@ -94,6 +94,10 @@ class NativeConsoleDashboard:
 
                 self._api_key_resolved = resolve_dashboard_api_key()
             except Exception:
+                # NOT leftover duplication: this outer guard covers the case
+                # where utils.secrets_manager itself can't import (stripped
+                # TUI-only env without the full secrets stack) — the env var
+                # is then the only possible source.
                 self._api_key_resolved = os.getenv("API_KEY")
         return self._api_key_resolved
 

--- a/scripts/native_console_dashboard.py
+++ b/scripts/native_console_dashboard.py
@@ -69,7 +69,7 @@ class NativeConsoleDashboard:
         """
         try:
             headers = {}
-            api_key = os.getenv("API_KEY")
+            api_key = self._dashboard_api_key()
             if api_key:
                 headers["X-API-Key"] = api_key
             response = requests.get(
@@ -83,6 +83,24 @@ class NativeConsoleDashboard:
             return data
         except Exception:
             return None
+
+    def _dashboard_api_key(self):
+        """X-API-Key for the trade-history API: env API_KEY first (dev/CI),
+        then OpenBao at secrets/dashboard field api_key — same resolution the
+        server itself uses, so vault-backed setups need no env plumbing."""
+        if not hasattr(self, "_api_key_resolved"):
+            key = os.getenv("API_KEY")
+            if not key:
+                try:
+                    from utils.secrets_manager import get_enhanced_secrets_manager
+
+                    key = get_enhanced_secrets_manager().get_secret(
+                        "DASHBOARD_API_KEY", warn_if_missing=False
+                    )
+                except Exception:
+                    key = None
+            self._api_key_resolved = key
+        return self._api_key_resolved
 
     def _get_json_cached(self, url, params=None, ttl=5.0):
         """GET a JSON endpoint through a small TTL cache.

--- a/tests/test_native_dashboard.py
+++ b/tests/test_native_dashboard.py
@@ -76,6 +76,56 @@ class TestDashboardApiKey:
         assert dash._dashboard_api_key() == "first"  # cached
 
 
+class TestSharedResolver:
+    """The env->OpenBao resolution is a single shared helper (review #46)."""
+
+    def test_vault_key_map_tuple_pinned(self):
+        # A typo in the path/field tuple would be invisible to mocked tests
+        from utils.secrets_manager import _VAULT_KEY_MAP
+
+        assert _VAULT_KEY_MAP["DASHBOARD_API_KEY"] == ("dashboard", "api_key")
+
+    def test_env_priority(self, monkeypatch):
+        from utils.secrets_manager import resolve_dashboard_api_key
+
+        monkeypatch.setenv("API_KEY", "from-env")
+        assert resolve_dashboard_api_key() == "from-env"
+
+    def test_vault_fallback(self, monkeypatch):
+        import utils.secrets_manager as smod
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        sm = MagicMock()
+        sm.get_secret.return_value = "from-vault"
+        monkeypatch.setattr(smod, "get_enhanced_secrets_manager", lambda: sm)
+        assert smod.resolve_dashboard_api_key() == "from-vault"
+        sm.get_secret.assert_called_once_with(
+            "DASHBOARD_API_KEY", warn_if_missing=False
+        )
+
+    def test_failure_logged_not_swallowed(self, monkeypatch, caplog):
+        import logging as _logging
+
+        import utils.secrets_manager as smod
+
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            smod,
+            "get_enhanced_secrets_manager",
+            lambda: (_ for _ in ()).throw(RuntimeError("vault down")),
+        )
+        with caplog.at_level(_logging.WARNING, logger="utils.secrets_manager"):
+            assert smod.resolve_dashboard_api_key() is None
+        assert any("OpenBao resolution failed" in r.message for r in caplog.records)
+
+    def test_server_module_uses_shared_resolver(self):
+        # Symmetry guard: the server must not re-grow its own copy
+        import trading.utils.trade_history_api as api
+        from utils.secrets_manager import resolve_dashboard_api_key
+
+        assert api.resolve_dashboard_api_key is resolve_dashboard_api_key
+
+
 class TestNetCache:
     def test_second_call_within_ttl_hits_cache(self, dash):
         with patch("requests.get", return_value=_resp(payload={"price": "1"})) as g:

--- a/tests/test_native_dashboard.py
+++ b/tests/test_native_dashboard.py
@@ -14,7 +14,10 @@ from scripts.native_console_dashboard import NativeConsoleDashboard
 
 
 @pytest.fixture
-def dash():
+def dash(monkeypatch):
+    # Pin the env key so the OpenBao fallback isn't exercised implicitly;
+    # TestDashboardApiKey covers the fallback explicitly.
+    monkeypatch.setenv("API_KEY", "fixture-key")
     return NativeConsoleDashboard()
 
 
@@ -47,6 +50,30 @@ class TestGetApiData:
         with patch("requests.get", return_value=_resp(payload=[])) as mock_get:
             dash.get_api_data("/trades")
         assert mock_get.call_args[1]["headers"] == {"X-API-Key": "sekrit"}
+
+
+class TestDashboardApiKey:
+    def test_env_key_takes_priority(self, dash, monkeypatch):
+        monkeypatch.setenv("API_KEY", "from-env")
+        assert dash._dashboard_api_key() == "from-env"
+
+    def test_openbao_fallback_when_env_absent(self, dash, monkeypatch):
+        monkeypatch.delenv("API_KEY", raising=False)
+        sm = MagicMock()
+        sm.get_secret.return_value = "from-vault"
+        with patch(
+            "utils.secrets_manager.get_enhanced_secrets_manager", return_value=sm
+        ):
+            assert dash._dashboard_api_key() == "from-vault"
+        sm.get_secret.assert_called_once_with(
+            "DASHBOARD_API_KEY", warn_if_missing=False
+        )
+
+    def test_resolution_cached_per_process(self, dash, monkeypatch):
+        monkeypatch.setenv("API_KEY", "first")
+        assert dash._dashboard_api_key() == "first"
+        monkeypatch.setenv("API_KEY", "second")
+        assert dash._dashboard_api_key() == "first"  # cached
 
 
 class TestNetCache:

--- a/trading/utils/trade_history_api.py
+++ b/trading/utils/trade_history_api.py
@@ -50,22 +50,9 @@ CORS(app)
 # ---------------------------------------------------------------------------
 
 
-def _resolve_dashboard_api_key():
-    """env API_KEY first, then OpenBao (secrets/dashboard api_key)."""
-    key = os.getenv("API_KEY")
-    if key:
-        return key
-    try:
-        from utils.secrets_manager import get_enhanced_secrets_manager
+from utils.secrets_manager import resolve_dashboard_api_key
 
-        return get_enhanced_secrets_manager().get_secret(
-            "DASHBOARD_API_KEY", warn_if_missing=False
-        )
-    except Exception:
-        return None
-
-
-_API_KEY = _resolve_dashboard_api_key()
+_API_KEY = resolve_dashboard_api_key()
 
 
 @app.before_request
@@ -374,7 +361,7 @@ def format_timestamp(ts):
 def safe_float(value):
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0.0
 
 

--- a/trading/utils/trade_history_api.py
+++ b/trading/utils/trade_history_api.py
@@ -43,10 +43,29 @@ CORS(app)
 # The Flask API was publicly accessible on 0.0.0.0:5050 with no authentication.
 # Any process on the network could read trade data or trigger actions.
 # Now every request (except /health) must supply the correct API key via header:
-#   X-API-Key: <value of API_KEY env variable>
-# Set the API_KEY environment variable before starting the bot.
+#   X-API-Key: <key>
+# Resolution order: API_KEY env var (dev/CI override), then OpenBao at
+# secrets/dashboard field api_key (store it with:
+#   bao kv put -mount=secrets dashboard api_key=<value>).
 # ---------------------------------------------------------------------------
-_API_KEY = os.getenv("API_KEY")
+
+
+def _resolve_dashboard_api_key():
+    """env API_KEY first, then OpenBao (secrets/dashboard api_key)."""
+    key = os.getenv("API_KEY")
+    if key:
+        return key
+    try:
+        from utils.secrets_manager import get_enhanced_secrets_manager
+
+        return get_enhanced_secrets_manager().get_secret(
+            "DASHBOARD_API_KEY", warn_if_missing=False
+        )
+    except Exception:
+        return None
+
+
+_API_KEY = _resolve_dashboard_api_key()
 
 
 @app.before_request

--- a/utils/secrets_manager.py
+++ b/utils/secrets_manager.py
@@ -33,6 +33,9 @@ _VAULT_KEY_MAP = {
     "BINANCE_API_SECRET": ("binance", "secret_key"),
     "BINANCE_FUTURES_TESTNET_API_KEY": ("binance_testnet", "api_key"),
     "BINANCE_FUTURES_TESTNET_API_SECRET": ("binance_testnet", "secret_key"),
+    # X-API-Key shared by the trade-history API and its dashboards
+    # (store: bao kv put -mount=secrets dashboard api_key=<value>)
+    "DASHBOARD_API_KEY": ("dashboard", "api_key"),
 }
 
 

--- a/utils/secrets_manager.py
+++ b/utils/secrets_manager.py
@@ -547,6 +547,26 @@ def get_enhanced_secrets_manager(
 
 
 # Backward compatibility function
+def resolve_dashboard_api_key() -> Optional[str]:
+    """X-API-Key shared by the trade-history API and its dashboards.
+
+    Resolution order: API_KEY env var first (dev/CI override), then OpenBao
+    at secrets/dashboard field api_key. Returns None when neither source has
+    it (callers fail closed). Vault failures are logged, never swallowed —
+    a silent None here means the whole dashboard 503s until restart.
+    """
+    key = os.environ.get("API_KEY")
+    if key:
+        return key
+    try:
+        return get_enhanced_secrets_manager().get_secret(
+            "DASHBOARD_API_KEY", warn_if_missing=False
+        )
+    except Exception as exc:
+        logger.warning(f"Dashboard API key: OpenBao resolution failed: {exc}")
+        return None
+
+
 def get_secrets_manager(logger: logging.Logger = None) -> EnhancedSecretsManager:
     """Backward compatibility wrapper"""
     return get_enhanced_secrets_manager(logger)


### PR DESCRIPTION
Follow-up to #44, prompted by the owner's (correct) question: *"don't you use the api key in openbao?"*

The dashboard auth key was the one secret still env-only while everything else lives in OpenBao. Both sides of the pair now resolve identically — **`API_KEY` env var first** (dev/CI override), **then OpenBao** `secrets/dashboard` field `api_key` via the enhanced secrets manager (new `_VAULT_KEY_MAP` entry, so `vault_admin --list` covers the path automatically).

Store it once:
```bash
bao kv put -mount=secrets dashboard api_key=$(openssl rand -hex 24)
```
…and neither the trade-history API nor the TUI needs any env plumbing (Vault must be unsealed, as for all secrets).

Tests: env priority, OpenBao fallback (mocked manager), per-process caching; dashboard suite 17 pass + server-side regressions green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)