### PR TITLE
fix(books): loss forensics — the losses were mostly bookkeeping fiction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,8 +92,11 @@ GRAFANA_API_KEY=your_grafana_api_key_here
 # Re-enable the legacy post-loop single-symbol execution (double-executes
 # the last symbol per cycle; off by default).
 # ELVIS_LEGACY_EXECUTION=0
-# Executor netting take-profit as fraction of opposite-position notional.
-# ELVIS_TP_PCT=0.0025
+# Executor NETTING thresholds (offset of the OPPOSITE position when an
+# incoming order nets against it) as fractions of that position's notional.
+# Distinct from ELVIS_SL_PCT, which stops out a position itself.
+# ELVIS_NET_SL_PCT=0.005
+# ELVIS_NET_TP_PCT=0.0025
 # Enable the independent BalancedStarter trader (hardcoded $1000 notional,
 # bypasses winrate filter/roadmap gates/Kelly/cooldowns; off by default).
 # ELVIS_BALANCED_STARTER=0

--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,8 @@ GRAFANA_API_KEY=your_grafana_api_key_here
 # Re-enable the legacy post-loop single-symbol execution (double-executes
 # the last symbol per cycle; off by default).
 # ELVIS_LEGACY_EXECUTION=0
+# Executor netting take-profit as fraction of opposite-position notional.
+# ELVIS_TP_PCT=0.0025
+# Enable the independent BalancedStarter trader (hardcoded $1000 notional,
+# bypasses winrate filter/roadmap gates/Kelly/cooldowns; off by default).
+# ELVIS_BALANCED_STARTER=0

--- a/main.py
+++ b/main.py
@@ -1188,8 +1188,15 @@ def main(mode: str, log_level: str):
                             except Exception as e:
                                 logger.debug(f"LLM sentiment analysis failed: {e}")
 
-                        # BALANCED STARTER STRATEGY - Only execute if not main strategy
-                        if strategy_mode != "balanced":
+                        # BALANCED STARTER STRATEGY - Only execute if not main strategy.
+                        # Gated OFF by default: it trades independently with a
+                        # hardcoded $1000 notional and its own bookkeeping,
+                        # bypassing the winrate filter, roadmap gates, Kelly
+                        # cap and cooldowns entirely.
+                        if (
+                            strategy_mode != "balanced"
+                            and os.getenv("ELVIS_BALANCED_STARTER", "0") == "1"
+                        ):
                             try:
                                 from trading.strategies.balanced_starter import (
                                     BalancedStarterStrategy,
@@ -1916,12 +1923,15 @@ def main(mode: str, log_level: str):
                                                     # Column order is pinned by
                                                     # tests/test_roadmap_wiring.py
                                                     _PNL_IDX = 6
+                                                    _SIDE_IDX = 3
                                                     _kelly_f = kelly_from_trades(
                                                         [
                                                             {"pnl": t[_PNL_IDX]}
                                                             for t in get_all_trades(
                                                                 limit=200
                                                             )
+                                                            if t[_SIDE_IDX]
+                                                            in ("BUY", "SELL")
                                                         ]
                                                     )
                                                     _kelly_cap = (
@@ -2104,33 +2114,26 @@ def main(mode: str, log_level: str):
                                         if quantity == 0 or entry_price <= 0:
                                             continue
 
-                                        # Get current price for this position
-                                        if pos_symbol == symbol:
-                                            position_current_price = current_price
-                                        else:
-                                            # Try to get current price from price_fetcher
-                                            position_current_price = (
-                                                price_fetcher.get_current_price(
-                                                    pos_symbol
-                                                )
+                                        # Get current price for this position.
+                                        # ALWAYS fetch per pos_symbol: the old
+                                        # `pos_symbol == symbol` shortcut paired
+                                        # the leftover loop symbol with a price
+                                        # computed from the BTC dataframe, so
+                                        # BNB positions were closed against BTC
+                                        # prices (fake -$553 "losses"). And a
+                                        # mock-price fallback here once booked a
+                                        # fictional +$816 close at $116,500 —
+                                        # if no live price exists, SKIP the
+                                        # position this cycle; fiction never
+                                        # enters the books.
+                                        position_current_price = (
+                                            price_fetcher.get_current_price(pos_symbol)
+                                        )
+                                        if not position_current_price:
+                                            logger.warning(
+                                                f"No live price for {pos_symbol}; skipping exit checks this cycle"
                                             )
-                                            if position_current_price is None:
-                                                # Fallback to executor's mock price for proper P&L calculation
-                                                try:
-                                                    position_current_price = (
-                                                        executor._get_mock_price(
-                                                            pos_symbol
-                                                        )
-                                                    )
-                                                    logger.debug(
-                                                        f"Using fallback mock price for {pos_symbol}: ${position_current_price:.2f}"
-                                                    )
-                                                except:
-                                                    # Final fallback - use entry price (no P&L change)
-                                                    position_current_price = entry_price
-                                                    logger.warning(
-                                                        f"Could not get price for {pos_symbol}, using entry price"
-                                                    )
+                                            continue
 
                                         # Calculate P&L percentage
                                         if side.upper() == "BUY":  # LONG position

--- a/tests/test_database_integration.py
+++ b/tests/test_database_integration.py
@@ -38,7 +38,7 @@ def test_database_integration():
     logger.info("2. Testing BUY trade recording...")
     try:
         record_trade("BTCUSDT", "BUY", 105000.0, 0.001, 0.0, 0.42)
-        add_open_position("BTCUSDT", 105000.0, 0.001, 1.0)
+        add_open_position("BTCUSDT", "BUY", 105000.0, 0.001, 1.0)
         logger.info("✅ BUY trade recorded successfully")
     except Exception as e:
         logger.error(f"❌ BUY trade recording failed: {e}")

--- a/tests/test_paper_fill_integrity.py
+++ b/tests/test_paper_fill_integrity.py
@@ -1,0 +1,74 @@
+"""Paper-fill integrity (review on #48): regression tests for the
+mock-price refusal (bug #3) and percent-of-notional netting (bug #4)."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+import trading.execution.binance_executor as bx
+from trading.execution.binance_executor import BinanceExecutor
+
+
+@pytest.fixture
+def ex():
+    e = BinanceExecutor(logger=logging.getLogger("t"))
+    e.db_available = True
+    return e
+
+
+class TestMockPriceRefusal:
+    def test_none_price_refused(self, ex):
+        with patch.object(bx, "record_trade") as rt:
+            assert ex.execute_sell("BTCUSDT", 1.0, None) == {}
+        rt.assert_not_called()  # nothing reaches the books
+
+    def test_zero_price_refused(self, ex):
+        with patch.object(bx, "record_trade") as rt:
+            assert ex.execute_buy("BTCUSDT", 1.0, 0.0) == {}
+        rt.assert_not_called()
+
+    def test_negative_price_refused(self, ex):
+        assert ex.execute_buy("BTCUSDT", 1.0, -5.0) == {}
+
+
+class TestNettingThresholds:
+    """Netting closes the OPPOSITE position only past pct-of-notional
+    thresholds (were hardcoded -$50/+$25 — unreachable at micro notional)."""
+
+    def _run(self, ex, current_price, monkeypatch, opp_entry=100.0, qty=1.0):
+        monkeypatch.delenv("ELVIS_NET_SL_PCT", raising=False)
+        monkeypatch.delenv("ELVIS_NET_TP_PCT", raising=False)
+        opp = (1, "BTCUSDT", "SELL", opp_entry, qty, 1.0, None)
+        calls = {}
+        with patch.object(bx, "get_open_positions", return_value=[opp]):
+            with patch.object(bx, "record_trade") as rt:
+                with patch.object(bx, "close_open_position") as cp:
+                    with patch.object(bx, "add_open_position"):
+                        with patch.object(
+                            ex,
+                            "_calculate_position_pnl",
+                            return_value=(opp_entry - current_price) * qty,
+                        ):
+                            ex.execute_buy("BTCUSDT", qty, current_price)
+        calls["recorded"] = rt.call_args_list
+        calls["closed"] = cp.called
+        return calls
+
+    def test_small_move_does_not_force_close(self, ex, monkeypatch):
+        # SELL from 100, price 100.2 -> pnl -0.2 = -0.2% of notional: within
+        # the 0.5% netting stop, so the opposite position must survive
+        calls = self._run(ex, current_price=100.2, monkeypatch=monkeypatch)
+        assert calls["closed"] is False
+
+    def test_loss_past_pct_forces_close(self, ex, monkeypatch):
+        # price 101 -> pnl -1.0 = -1% of $100 notional: past the 0.5% stop
+        calls = self._run(ex, current_price=101.0, monkeypatch=monkeypatch)
+        assert calls["closed"] is True
+        # and the close is recorded with the REAL caller price, never a mock
+        assert calls["recorded"][0].args[2] == 101.0
+
+    def test_profit_past_pct_takes_profit(self, ex, monkeypatch):
+        # price 99 -> pnl +1.0 = +1% > 0.25% target
+        calls = self._run(ex, current_price=99.0, monkeypatch=monkeypatch)
+        assert calls["closed"] is True

--- a/tests/test_trade_recording_validation.py
+++ b/tests/test_trade_recording_validation.py
@@ -1,0 +1,26 @@
+"""DB recording validation (loss-forensics fix): a test once called
+add_open_position with a missing side argument, writing side='105000.0'
+rows that later 'closed' for a fictional -$63,914 — poisoning Kelly and
+every win-rate statistic. Invalid sides are now rejected at the door."""
+
+from unittest.mock import patch
+
+from utils import paper_trade_db as db
+
+
+def test_record_trade_rejects_price_as_side():
+    with patch.object(db, "get_conn") as gc:
+        db.record_trade("BTCUSDT", 105000.0, 64000.0, 1.0)
+    gc.assert_not_called()  # rejected before touching the DB
+
+
+def test_add_open_position_rejects_invalid_side():
+    with patch.object(db, "get_conn") as gc:
+        db.add_open_position("BTCUSDT", 105000.0, 0.001, 1.0)
+    gc.assert_not_called()
+
+
+def test_valid_sides_pass_through():
+    with patch.object(db, "get_conn", return_value=None) as gc:
+        db.record_trade("BTCUSDT", "buy", 64000.0, 1.0)  # case-normalized
+    gc.assert_called_once()

--- a/trading/execution/binance_executor.py
+++ b/trading/execution/binance_executor.py
@@ -438,10 +438,10 @@ class BinanceExecutor(BaseExecutor):
                         existing_quantity = float(opposite_position[4])
                         new_quantity = existing_quantity - quantity
 
-                        if new_quantity <= 0.000001:
-                            close_open_position(symbol, opposite_side)
-                        else:
-                            close_open_position(symbol, opposite_side)
+                        # Fully close the opposite position; if this order only
+                        # partially offset it, re-open the remainder.
+                        close_open_position(symbol, opposite_side)
+                        if new_quantity > 0.000001:
                             add_open_position(
                                 symbol,
                                 opposite_side,

--- a/trading/execution/binance_executor.py
+++ b/trading/execution/binance_executor.py
@@ -351,10 +351,11 @@ class BinanceExecutor(BaseExecutor):
         self, symbol: str, side: str, quantity: float, price: float = None
     ) -> Dict[str, Any]:
         try:
-            if not price:
-                # No caller-supplied price: refuse rather than fill at the
-                # hardcoded mock (mock fills once booked entries at $116,500
-                # while BTC traded at $64k, fabricating +$816 "profits").
+            if price is None or price <= 0:
+                # No valid caller-supplied price: refuse rather than fill at
+                # the hardcoded mock (mock fills once booked entries at
+                # $116,500 while BTC traded at $64k, fabricating +$816
+                # "profits").
                 self.logger.error(
                     f"[PAPER TRADE] REFUSED {side} {symbol}: no live price supplied"
                 )
@@ -391,15 +392,19 @@ class BinanceExecutor(BaseExecutor):
                 # notional (were hardcoded -$50/+$25 from the $1000 era —
                 # relics #6 and #7 — which shadow-closed positions in
                 # conflict with the main loop's exits)
+                # NOTE: these NETTING thresholds apply to the OPPOSITE
+                # position when an incoming order would offset it — distinct
+                # semantics (and env vars) from main._stop_loss_threshold,
+                # which stops out the position itself via ELVIS_SL_PCT.
                 _opp_notional = float(opposite_position[3]) * float(
                     opposite_position[4]
                 )
                 try:
-                    _sl_pct = float(os.getenv("ELVIS_SL_PCT", "0.005"))
+                    _sl_pct = float(os.getenv("ELVIS_NET_SL_PCT", "0.005"))
                 except ValueError:
                     _sl_pct = 0.005
                 try:
-                    _tp_pct = float(os.getenv("ELVIS_TP_PCT", "0.0025"))
+                    _tp_pct = float(os.getenv("ELVIS_NET_TP_PCT", "0.0025"))
                 except ValueError:
                     _tp_pct = 0.0025
                 stop_loss_threshold = -abs(_opp_notional * _sl_pct)

--- a/trading/execution/binance_executor.py
+++ b/trading/execution/binance_executor.py
@@ -351,7 +351,15 @@ class BinanceExecutor(BaseExecutor):
         self, symbol: str, side: str, quantity: float, price: float = None
     ) -> Dict[str, Any]:
         try:
-            current_price = price if price else self._get_mock_price(symbol)
+            if not price:
+                # No caller-supplied price: refuse rather than fill at the
+                # hardcoded mock (mock fills once booked entries at $116,500
+                # while BTC traded at $64k, fabricating +$816 "profits").
+                self.logger.error(
+                    f"[PAPER TRADE] REFUSED {side} {symbol}: no live price supplied"
+                )
+                return {}
+            current_price = price
             fee = self.fee_calculator.calculate_trading_fee(
                 current_price, quantity, is_maker=False, is_futures=True
             )
@@ -379,11 +387,23 @@ class BinanceExecutor(BaseExecutor):
                 # Only close opposite position if stop loss or profit taking conditions are met
                 close_opposite = False
 
-                # 🎯 BIGGER TRADES OPTIMIZED RISK MANAGEMENT
-                stop_loss_threshold = (
-                    -50.0
-                )  # Larger stop for bigger positions: $50.00 loss per position
-                profit_target = 25.0  # Bigger target for larger positions: $25.00 profit per position
+                # Netting thresholds as % of the OPPOSITE position's
+                # notional (were hardcoded -$50/+$25 from the $1000 era —
+                # relics #6 and #7 — which shadow-closed positions in
+                # conflict with the main loop's exits)
+                _opp_notional = float(opposite_position[3]) * float(
+                    opposite_position[4]
+                )
+                try:
+                    _sl_pct = float(os.getenv("ELVIS_SL_PCT", "0.005"))
+                except ValueError:
+                    _sl_pct = 0.005
+                try:
+                    _tp_pct = float(os.getenv("ELVIS_TP_PCT", "0.0025"))
+                except ValueError:
+                    _tp_pct = 0.0025
+                stop_loss_threshold = -abs(_opp_notional * _sl_pct)
+                profit_target = abs(_opp_notional * _tp_pct)
 
                 if potential_pnl < stop_loss_threshold:
                     self.logger.warning(

--- a/utils/paper_trade_db.py
+++ b/utils/paper_trade_db.py
@@ -139,7 +139,17 @@ def init_db():
         conn.close()
 
 
+VALID_SIDES = ("BUY", "SELL", "TEST")
+
+
 def record_trade(symbol, side, price, quantity, pnl=0.0, fee=0.0, timestamp=None):
+    # Reject corrupt rows at the door: a positional-args mistake once wrote
+    # side='105000.0' and poisoned every win-rate/Kelly statistic with a
+    # fake -$63k loss.
+    if str(side).upper() not in VALID_SIDES:
+        print(f"[ERROR] record_trade rejected invalid side {side!r} for {symbol}")
+        return
+    side = str(side).upper()
     if timestamp is None:
         timestamp = datetime.now()
     conn = get_conn()
@@ -180,6 +190,10 @@ def record_trade(symbol, side, price, quantity, pnl=0.0, fee=0.0, timestamp=None
 
 
 def add_open_position(symbol, side, entry_price, quantity, leverage=1.0):
+    if str(side).upper() not in ("BUY", "SELL"):
+        print(f"[ERROR] add_open_position rejected invalid side {side!r} for {symbol}")
+        return
+    side = str(side).upper()
     conn = get_conn()
     if conn is None:
         print(f"[WARNING] Cannot add open position - database not available")


### PR DESCRIPTION
Owner asked: *"learn from the last trades to understand why Elvis lost money, modify the system accordingly."* Forensic analysis of every close found the recorded losses dominated by **five accounting bugs, not market decisions**:

| # | Fiction | Mechanism | Fix |
|---|---|---|---|
| 1 | −$63,914 ×2 | `test_database_integration.py` called `add_open_position` **missing the side arg** → `side='105000.0'`, entry $0.001 rows in the real DB, later "closed" at market | test fixed + `record_trade`/`add_open_position` now **reject invalid sides** (3 tests) |
| 2 | −$553, −$68 | BNB positions closed against **BTC prices** — the `pos_symbol == symbol` shortcut paired the leftover loop symbol with a BTC-derived price | price always fetched per `pos_symbol` |
| 3 | +$816 | closes/fills at the hardcoded **mock prices** ($116,500 / $844.58) | no live price → position skipped; executor **refuses** fills without a caller price |
| 4 | duplicate closes | executor shadow exits (hardcoded −$50/+$25 — $1000-era relics **#6–#7**) fighting the main loop's exits | percent-of-notional netting (`ELVIS_SL_PCT` / new `ELVIS_TP_PCT`) |
| 5 | ungated volume | **BalancedStarter** trading independently at hardcoded **$1000 notional** on a $100 account, bypassing winrate filter, roadmap gates, Kelly, cooldowns | gated behind `ELVIS_BALANCED_STARTER` (default off); Kelly feed filters to real BUY/SELL closes |

One-time data correction: **7 provably-fabricated rows deleted** (each listed in the session log before removal). The honest book: **153 real closes, −$338.33 total** — the number the adaptive-ensemble learning loop now actually trains on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)